### PR TITLE
Bug fix open dl button

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - main
+      - bug-fix-open-dl-button
       - 'release/**'
     tags:
       - '*'

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - main
-      - bug-fix-open-dl-button
       - 'release/**'
     tags:
       - '*'

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -43,7 +43,7 @@ void open_folder(const std::string &folder_path)
 #ifdef __APPLE__
 		"open \"" + folder_path + "\"";
 #else
-			"xdg-open \"" + folder_path + "\"";
+		"xdg-open \"" + folder_path + "\"";
 #endif
 	int return_value = system(command.c_str());
 	blog(LOG_INFO, "Open command returned %d", return_value);


### PR DESCRIPTION
This pull request refactors the `open_folder` function in `src/SettingsDialog.cpp` to improve platform-specific handling for opening folders, especially on Windows. It enhances path conversion and error reporting, and ensures safer command execution on macOS and Linux.

Platform-specific improvements:

* On Windows, the code now converts the folder path from UTF-8 to a wide string using `MultiByteToWideChar`, replaces forward slashes with backslashes, and uses `"explore"` instead of `"open"` with `ShellExecuteW`. It also adds detailed error logging if path conversion or folder opening fails.

Cross-platform command safety:

* On macOS and Linux, the folder path is now wrapped in quotes in the shell command to handle paths with spaces or special characters, and the log message is generalized to indicate the result of the open command.