### PR TITLE
Use windows_shared_memory for shared memory handling

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -67,16 +67,13 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 {
 	UNUSED_PARAMETER(effect);
 	draw_source_data_t *context = data;
-	blog(LOG_INFO, "L70");
 	if (!context->source)
 		return;
 
-	blog(LOG_INFO, "L74");
 	if (context->processing)
 		return;
 	context->processing = true;
 	obs_source_t *source = obs_weak_source_get_source(context->source);
-	blog(LOG_INFO, "L79");
 	if (!source) {
 		context->processing = false;
 		return;
@@ -86,14 +83,12 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 	uint32_t height = context->source_height;
 
 	gs_texrender_t *render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
-	blog(LOG_INFO, "L89");
 	if (!gs_texrender_begin(render, width, height)) {
 		obs_source_release(source);
 		context->processing = false;
 		gs_texrender_destroy(render);
 		return;
 	}
-	blog(LOG_INFO, "L96");
 
 	ensure_shared_memory_exists(context);
 
@@ -104,7 +99,6 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 
 	obs_source_video_render(source);
 	gs_texrender_end(render);
-	blog(LOG_INFO, "L107");
 
 	gs_texture_t *texture = gs_texrender_get_texture(render);
 	if (texture) {
@@ -126,12 +120,10 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 			blog(LOG_ERROR, "Failed to capture stage surface");
 		}
 	}
-	blog(LOG_INFO, "126");
 
 	gs_texrender_destroy(render);
 	obs_source_release(source);
 
-	blog(LOG_INFO, "calling read_shared_memory");
 	if (!read_shared_memory(context)) {
 		return;
 	}

--- a/src/draw.c
+++ b/src/draw.c
@@ -67,13 +67,16 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 {
 	UNUSED_PARAMETER(effect);
 	draw_source_data_t *context = data;
+	blog(LOG_INFO, "L70");
 	if (!context->source)
 		return;
 
+	blog(LOG_INFO, "L74");
 	if (context->processing)
 		return;
 	context->processing = true;
 	obs_source_t *source = obs_weak_source_get_source(context->source);
+	blog(LOG_INFO, "L79");
 	if (!source) {
 		context->processing = false;
 		return;
@@ -90,7 +93,7 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 		gs_texrender_destroy(render);
 		return;
 	}
-	blog(LOG_INFO, "L93");
+	blog(LOG_INFO, "L96");
 
 	ensure_shared_memory_exists(context);
 
@@ -101,7 +104,7 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 
 	obs_source_video_render(source);
 	gs_texrender_end(render);
-	blog(LOG_INFO, "L104");
+	blog(LOG_INFO, "L107");
 
 	gs_texture_t *texture = gs_texrender_get_texture(render);
 	if (texture) {

--- a/src/draw.c
+++ b/src/draw.c
@@ -67,16 +67,13 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 {
 	UNUSED_PARAMETER(effect);
 	draw_source_data_t *context = data;
-	blog(LOG_INFO, "L70");
 	if (!context->source)
 		return;
 
-	blog(LOG_INFO, "L74");
 	if (context->processing)
 		return;
 	context->processing = true;
 	obs_source_t *source = obs_weak_source_get_source(context->source);
-	blog(LOG_INFO, "L79");
 	if (!source) {
 		context->processing = false;
 		return;
@@ -93,6 +90,7 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 		gs_texrender_destroy(render);
 		return;
 	}
+	blog(LOG_INFO, "L93");
 
 	ensure_shared_memory_exists(context);
 
@@ -103,6 +101,7 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 
 	obs_source_video_render(source);
 	gs_texrender_end(render);
+	blog(LOG_INFO, "L104");
 
 	gs_texture_t *texture = gs_texrender_get_texture(render);
 	if (texture) {
@@ -124,6 +123,7 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 			blog(LOG_ERROR, "Failed to capture stage surface");
 		}
 	}
+	blog(LOG_INFO, "126");
 
 	gs_texrender_destroy(render);
 	obs_source_release(source);

--- a/src/draw.c
+++ b/src/draw.c
@@ -67,13 +67,16 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 {
 	UNUSED_PARAMETER(effect);
 	draw_source_data_t *context = data;
+	blog(LOG_INFO, "L70");
 	if (!context->source)
 		return;
 
+	blog(LOG_INFO, "L74");
 	if (context->processing)
 		return;
 	context->processing = true;
 	obs_source_t *source = obs_weak_source_get_source(context->source);
+	blog(LOG_INFO, "L79");
 	if (!source) {
 		context->processing = false;
 		return;
@@ -83,6 +86,7 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 	uint32_t height = context->source_height;
 
 	gs_texrender_t *render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+	blog(LOG_INFO, "L89");
 	if (!gs_texrender_begin(render, width, height)) {
 		obs_source_release(source);
 		context->processing = false;
@@ -124,6 +128,7 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 	gs_texrender_destroy(render);
 	obs_source_release(source);
 
+	blog(LOG_INFO, "calling read_shared_memory");
 	if (!read_shared_memory(context)) {
 		return;
 	}

--- a/src/draw.c
+++ b/src/draw.c
@@ -124,7 +124,6 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 	gs_texrender_destroy(render);
 	obs_source_release(source);
 
-	blog(LOG_INFO, "calling read_shared_memory");
 	if (!read_shared_memory(context)) {
 		return;
 	}

--- a/src/draw.c
+++ b/src/draw.c
@@ -124,6 +124,7 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 	gs_texrender_destroy(render);
 	obs_source_release(source);
 
+	blog(LOG_INFO, "calling read_shared_memory");
 	if (!read_shared_memory(context)) {
 		return;
 	}

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -108,6 +108,7 @@ extern "C" void destroy_shared_memory(draw_source_data_t *context)
 
 extern "C" bool read_shared_memory(draw_source_data_t *context)
 {
+	using namespace boost::interprocess;
 	if (!context->shared_frame)
 		return false;
 	

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -110,7 +110,7 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 {
 	using namespace boost::interprocess;
 
-	blog(LOG_INFO, "reading shared memory")
+	blog(LOG_INFO, "reading shared memory");
 	
 	try {
 		windows_shared_memory shm(

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -83,6 +83,14 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 			read_write,
 			required_size
 		);
+		auto *region = new mapped_region(shm, read_write);
+		context->region = region;
+		context->shared_frame = region->get_address();
+	
+		// Zero-init header (good hygiene)
+		memset(context->shared_frame, 0, sizeof(shared_frame_header_t));
+	
+		blog(LOG_INFO, "Shared memory initialized (%zu bytes)", required_size);
 	}
 	catch (const interprocess_exception &e) {
 		windows_shared_memory shm(
@@ -91,15 +99,15 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 			read_write,
 			required_size
 		);
+		auto *region = new mapped_region(shm, read_write);
+		context->region = region;
+		context->shared_frame = region->get_address();
+
+		// Zero-init header (good hygiene)
+		memset(context->shared_frame, 0, sizeof(shared_frame_header_t));
+	
+		blog(LOG_INFO, "Shared memory initialized (%zu bytes)", required_size);
 	}
-	auto *region = new mapped_region(shm, read_write);
-	context->region = region;
-	context->shared_frame = region->get_address();
-
-	// Zero-init header (good hygiene)
-	memset(context->shared_frame, 0, sizeof(shared_frame_header_t));
-
-	blog(LOG_INFO, "Shared memory initialized (%zu bytes)", required_size);
 }
 
 

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -141,37 +141,37 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 		context->display_height = python_header->height;
 
 		blog(LOG_INFO, "Python shared memory attached");
+	
+		if (context->display_texture)
+			gs_texture_destroy(context->display_texture);
+	
+		context->display_texture = gs_texture_create(
+			context->display_width,
+			context->display_height,
+			GS_RGBA,
+			1,
+			nullptr,
+			GS_DYNAMIC
+		);
+	
+		blog(LOG_INFO, "Display texture recreated (%ux%u)",
+			 context->display_width,
+			 context->display_height);
+	
+	
+		uint8_t *image_data = static_cast<uint8_t *>(region.get_address()) + sizeof(shared_frame_header_t);
+	
+		gs_texture_set_image(
+			context->display_texture,
+			image_data,
+			context->display_width * 4,
+			false
+		);
 	}
 	catch (const interprocess_exception &) {
 		context->processing = false;
 		return false;
 	}
-
-	if (context->display_texture)
-		gs_texture_destroy(context->display_texture);
-
-	context->display_texture = gs_texture_create(
-		context->display_width,
-		context->display_height,
-		GS_RGBA,
-		1,
-		nullptr,
-		GS_DYNAMIC
-	);
-
-	blog(LOG_INFO, "Display texture recreated (%ux%u)",
-		 context->display_width,
-		 context->display_height);
-
-
-	uint8_t *image_data = static_cast<uint8_t *>(region.get_address()) + sizeof(shared_frame_header_t);
-
-	gs_texture_set_image(
-		context->display_texture,
-		image_data,
-		context->display_width * 4,
-		false
-	);
 
 	return true;
 }

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -109,8 +109,6 @@ extern "C" void destroy_shared_memory(draw_source_data_t *context)
 extern "C" bool read_shared_memory(draw_source_data_t *context)
 {
 	using namespace boost::interprocess;
-
-	blog(LOG_INFO, "reading shared memory");
 	
 	try {
 		windows_shared_memory shm(

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -123,21 +123,21 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 		auto *python_header =
 			static_cast<shared_frame_header_t *>(region.get_address());
 
+				// Validate header
+		if (python_header->width == 0 || python_header->height == 0) {
+			blog(LOG_ERROR, "Size of the image in the header are null");
+			return false;
+		}
+	
+		context->display_width  = python_header->width;
+		context->display_height = python_header->height;
+
 		blog(LOG_INFO, "Python shared memory attached");
 	}
 	catch (const interprocess_exception &e) {
 		blog(LOG_ERROR, "Failed to open Python SHM: %s", e.what());
 		return false;
 	}
-
-	// Validate header
-	if (python_header->width == 0 || python_header->height == 0) {
-		blog(LOG_ERROR, "Size of the image in the header are null");
-		return false;
-	}
-
-	context->display_width  = header->width;
-	context->display_height = header->height;
 
 	if (context->display_texture)
 		gs_texture_destroy(context->display_texture);

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -101,7 +101,6 @@ extern "C" void destroy_shared_memory(draw_source_data_t *context)
 extern "C" bool read_shared_memory(draw_source_data_t *context)
 {
 	using namespace boost::interprocess;
-	blog(LOG_INFO, "reading shared memory");
 
 	try {
 #ifdef _WIN32

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -100,8 +100,6 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 
 		// Zero-init header (good hygiene)
 		memset(context->shared_frame, 0, sizeof(shared_frame_header_t));
-	
-		blog(LOG_INFO, "Shared memory initialized (%zu bytes)", required_size);
 	}
 }
 
@@ -139,8 +137,6 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 	
 		context->display_width  = python_header->width;
 		context->display_height = python_header->height;
-
-		blog(LOG_INFO, "Python shared memory attached");
 	
 		if (context->display_texture)
 			gs_texture_destroy(context->display_texture);
@@ -152,12 +148,7 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 			1,
 			nullptr,
 			GS_DYNAMIC
-		);
-	
-		blog(LOG_INFO, "Display texture recreated (%ux%u)",
-			 context->display_width,
-			 context->display_height);
-	
+		);	
 	
 		uint8_t *image_data = static_cast<uint8_t *>(region->get_address()) + sizeof(shared_frame_header_t);
 	

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -92,7 +92,7 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 	
 		blog(LOG_INFO, "Shared memory initialized (%zu bytes)", required_size);
 	}
-	catch (const interprocess_exception &e) {
+	catch (const interprocess_exception &) {
 		windows_shared_memory shm(
 			open_only,
 			OBS_SHM_NAME,

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -101,6 +101,7 @@ extern "C" void destroy_shared_memory(draw_source_data_t *context)
 extern "C" bool read_shared_memory(draw_source_data_t *context)
 {
 	using namespace boost::interprocess;
+	blog(LOG_INFO, "reading shared memory");
 
 	try {
 #ifdef _WIN32
@@ -130,7 +131,8 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 		uint8_t *image_data = static_cast<uint8_t *>(region.get_address()) + sizeof(shared_frame_header_t);
 
 		gs_texture_set_image(context->display_texture, image_data, context->display_width * 4, false);
-	} catch (const interprocess_exception &) {
+	} catch (const interprocess_exception &e) {
+		blog(LOG_INFO, "Failed to read shared memory: %s", e.what());
 		context->processing = false;
 		return false;
 	}

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -137,6 +137,7 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 	}
 	catch (const interprocess_exception &e) {
 		blog(LOG_ERROR, "Failed to open Python SHM: %s", e.what());
+		context->processing = false;
 		return false;
 	}
 

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -71,6 +71,7 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 		memset(context->shared_frame, 0, sizeof(shared_frame_header_t));
 	} catch (const interprocess_exception &e) {
 #ifdef _WIN32
+		UNUSED_PARAMETER(e);
 		windows_shared_memory shm(open_only, OBS_SHM_NAME, read_write);
 
 		auto *region = new mapped_region(shm, read_write);

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -120,8 +120,7 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 		auto *region = new mapped_region(shm, read_only);
 		context->region = region;
 
-		auto *python_header =
-			static_cast<shared_frame_header_t *>(region.get_address());
+		auto *python_header = static_cast<shared_frame_header_t *>(region.get_address());
 
 				// Validate header
 		if (python_header->width == 0 || python_header->height == 0) {

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -83,19 +83,23 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 			read_write,
 			required_size
 		);
-
-		auto *region = new mapped_region(shm, read_write);
-		context->region = region;
-		context->shared_frame = region->get_address();
-
-		// Zero-init header (good hygiene)
-		memset(context->shared_frame, 0, sizeof(shared_frame_header_t));
-
-		blog(LOG_INFO, "Shared memory initialized (%zu bytes)", required_size);
 	}
 	catch (const interprocess_exception &e) {
-		blog(LOG_ERROR, "Shared memory init failed: %s", e.what());
+		windows_shared_memory shm(
+			open_only,
+			OBS_SHM_NAME,
+			read_write,
+			required_size
+		);
 	}
+	auto *region = new mapped_region(shm, read_write);
+	context->region = region;
+	context->shared_frame = region->get_address();
+
+	// Zero-init header (good hygiene)
+	memset(context->shared_frame, 0, sizeof(shared_frame_header_t));
+
+	blog(LOG_INFO, "Shared memory initialized (%zu bytes)", required_size);
 }
 
 

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -25,6 +25,7 @@ extern "C" void write_message_to_shared_memory(draw_source_data_t *context, uint
 	auto *header = static_cast<shared_frame_header_t *>(context->shared_frame);
 	header->width = width;
 	header->height = height;
+	blog(LOG_INFO, "writting to shared mem");
 
 	uint8_t *frame_data = static_cast<uint8_t *>(context->shared_frame) + sizeof(shared_frame_header_t);
 	for (uint32_t y = 0; y < height; y++) {
@@ -48,6 +49,7 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 
 	context->region = static_cast<void *>(new mapped_region(shm, read_write));
 	context->shared_frame = static_cast<mapped_region *>(context->region)->get_address();
+	blog(LOG_INFO, "shared memory initialized");
 }
 
 extern "C" void destroy_shared_memory(draw_source_data_t *context)

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -11,62 +11,46 @@
 #include "shared_memory_wrapper.h"
 
 #include <boost/interprocess/shared_memory_object.hpp>
-#include <boost/interprocess/windows_shared_memory.hpp>
 #include <boost/interprocess/mapped_region.hpp>
+#ifdef _WIN32
+#include <boost/interprocess/windows_shared_memory.hpp>
+#endif
 
 struct shared_frame_header {
 	uint32_t width;
 	uint32_t height;
 };
 typedef struct shared_frame_header shared_frame_header_t;
-extern "C" void write_message_to_shared_memory(
-	draw_source_data_t *context,
-	uint8_t *frame,
-	uint32_t linesize,
-	uint32_t width,
-	uint32_t height)
+extern "C" void write_message_to_shared_memory(draw_source_data_t *context, uint8_t *frame, uint32_t linesize,
+					       uint32_t width, uint32_t height)
 {
 	if (!context->shared_frame)
 		return;
 
 	auto *header = static_cast<shared_frame_header_t *>(context->shared_frame);
 
-	header->width  = width;
+	header->width = width;
 	header->height = height;
 
-	uint8_t *frame_data =
-		static_cast<uint8_t *>(context->shared_frame) +
-		sizeof(shared_frame_header_t);
+	uint8_t *frame_data = static_cast<uint8_t *>(context->shared_frame) + sizeof(shared_frame_header_t);
 
 	for (uint32_t y = 0; y < height; y++) {
-		memcpy(
-			frame_data + size_t(y) * width * 4,
-			frame + size_t(y) * linesize,
-			size_t(width) * 4
-		);
+		memcpy(frame_data + size_t(y) * width * 4, frame + size_t(y) * linesize, size_t(width) * 4);
 	}
 }
-
 
 extern "C" void init_shared_memory(draw_source_data_t *context)
 {
 	using namespace boost::interprocess;
 
-	// Guard against invalid sizes (VERY IMPORTANT)
 	if (context->source_width == 0 || context->source_height == 0) {
 		blog(LOG_WARNING, "Shared memory not initialized: invalid frame size");
 		return;
 	}
 
-	// Compute size safely
-	size_t pixel_bytes =
-		size_t(context->source_width) *
-		size_t(context->source_height) * 4;
+	size_t pixel_bytes = size_t(context->source_width) * size_t(context->source_height) * 4;
+	size_t required_size = sizeof(shared_frame_header_t) + pixel_bytes;
 
-	size_t required_size =
-		sizeof(shared_frame_header_t) + pixel_bytes;
-
-	// Cleanup previous mapping (if any)
 	if (context->region) {
 		delete static_cast<mapped_region *>(context->region);
 		context->region = nullptr;
@@ -74,41 +58,41 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 	}
 
 	try {
-		// OBS MUST be the creator
-		windows_shared_memory shm(
-			create_only,
-			OBS_SHM_NAME,
-			read_write,
-			required_size
-		);
-		auto *region = new mapped_region(shm, read_write);
-		context->region = region;
-		context->shared_frame = region->get_address();
-	
-		// Zero-init header (good hygiene)
-		memset(context->shared_frame, 0, sizeof(shared_frame_header_t));
-	}
-	catch (const interprocess_exception &) {
-		windows_shared_memory shm(
-			open_only,
-			OBS_SHM_NAME,
-			read_write
-		);
+#ifdef _WIN32
+		windows_shared_memory shm(create_only, OBS_SHM_NAME, read_write, required_size);
+#else
+		shared_memory_object shm(open_or_create, OBS_SHM_NAME, read_write);
+		shm.truncate(static_cast<offset_t>(required_size));
+#endif
 		auto *region = new mapped_region(shm, read_write);
 		context->region = region;
 		context->shared_frame = region->get_address();
 
-		// Zero-init header (good hygiene)
 		memset(context->shared_frame, 0, sizeof(shared_frame_header_t));
+	} catch (const interprocess_exception &e) {
+#ifdef _WIN32
+		windows_shared_memory shm(open_only, OBS_SHM_NAME, read_write);
+
+		auto *region = new mapped_region(shm, read_write);
+		context->region = region;
+		context->shared_frame = region->get_address();
+
+		memset(context->shared_frame, 0, sizeof(shared_frame_header_t));
+#else
+		blog(LOG_ERROR, "Failed to open or create shared memory: %s", e.what());
+#endif
 	}
 }
-
 
 extern "C" void destroy_shared_memory(draw_source_data_t *context)
 {
 	using namespace boost::interprocess;
+#ifdef _WIN32
 	shared_memory_object::remove(OBS_SHM_NAME);
 	shared_memory_object::remove(PYTHON_SHM_NAME);
+#else
+	delete static_cast<mapped_region *>(context->region);
+#endif
 	context->region = nullptr;
 	context->shared_frame = nullptr;
 }
@@ -116,57 +100,42 @@ extern "C" void destroy_shared_memory(draw_source_data_t *context)
 extern "C" bool read_shared_memory(draw_source_data_t *context)
 {
 	using namespace boost::interprocess;
-	
+
 	try {
-		windows_shared_memory shm(
-			open_only,
-			PYTHON_SHM_NAME,
-			read_only
-		);
+#ifdef _WIN32
+		windows_shared_memory shm(open_only, PYTHON_SHM_NAME, read_only);
+#else
+		shared_memory_object shm(open_only, PYTHON_SHM_NAME, read_only);
+#endif
 
-		auto *region = new mapped_region(shm, read_only);
-		context->region = region;
+		mapped_region region(shm, read_only);
 
-		auto *python_header = static_cast<shared_frame_header_t *>(region->get_address());
+		auto *python_header = static_cast<shared_frame_header_t *>(region.get_address());
 
-				// Validate header
 		if (python_header->width == 0 || python_header->height == 0) {
 			blog(LOG_ERROR, "Size of the image in the header are null");
 			return false;
 		}
-	
-		context->display_width  = python_header->width;
+
+		context->display_width = python_header->width;
 		context->display_height = python_header->height;
-	
+
 		if (context->display_texture)
 			gs_texture_destroy(context->display_texture);
-	
-		context->display_texture = gs_texture_create(
-			context->display_width,
-			context->display_height,
-			GS_RGBA,
-			1,
-			nullptr,
-			GS_DYNAMIC
-		);	
-	
-		uint8_t *image_data = static_cast<uint8_t *>(region->get_address()) + sizeof(shared_frame_header_t);
-	
-		gs_texture_set_image(
-			context->display_texture,
-			image_data,
-			context->display_width * 4,
-			false
-		);
-	}
-	catch (const interprocess_exception &) {
+
+		context->display_texture = gs_texture_create(context->display_width, context->display_height, GS_RGBA,
+							     1, nullptr, GS_DYNAMIC);
+
+		uint8_t *image_data = static_cast<uint8_t *>(region.get_address()) + sizeof(shared_frame_header_t);
+
+		gs_texture_set_image(context->display_texture, image_data, context->display_width * 4, false);
+	} catch (const interprocess_exception &) {
 		context->processing = false;
 		return false;
 	}
 
 	return true;
 }
-
 
 extern "C" void ensure_shared_memory_exists(draw_source_data_t *context)
 {

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -96,8 +96,7 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 		windows_shared_memory shm(
 			open_only,
 			OBS_SHM_NAME,
-			read_write,
-			required_size
+			read_write
 		);
 		auto *region = new mapped_region(shm, read_write);
 		context->region = region;

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -72,8 +72,6 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 		context->region = nullptr;
 		context->shared_frame = nullptr;
 	}
-	if (context->shared_frame)
-		blog(LOG_INFO, "shared memory not empty");
 
 	try {
 		// OBS MUST be the creator
@@ -89,8 +87,6 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 	
 		// Zero-init header (good hygiene)
 		memset(context->shared_frame, 0, sizeof(shared_frame_header_t));
-	
-		blog(LOG_INFO, "Shared memory initialized (%zu bytes)", required_size);
 	}
 	catch (const interprocess_exception &) {
 		windows_shared_memory shm(
@@ -146,8 +142,7 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 
 		blog(LOG_INFO, "Python shared memory attached");
 	}
-	catch (const interprocess_exception &e) {
-		blog(LOG_ERROR, "Failed to open Python SHM: %s", e.what());
+	catch (const interprocess_exception &) {
 		context->processing = false;
 		return false;
 	}
@@ -169,9 +164,7 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 		 context->display_height);
 
 
-	uint8_t *image_data =
-		static_cast<uint8_t *>(context->shared_frame) +
-		sizeof(shared_frame_header_t);
+	uint8_t *image_data = static_cast<uint8_t *>(region.get_address()) + sizeof(shared_frame_header_t);
 
 	gs_texture_set_image(
 		context->display_texture,

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -72,6 +72,8 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 		context->region = nullptr;
 		context->shared_frame = nullptr;
 	}
+	if (context->shared_frame)
+		blog(LOG_INFO, "shared memory not empty");
 
 	try {
 		// OBS MUST be the creator

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -116,6 +116,7 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 
 		if (python_header->width == 0 || python_header->height == 0) {
 			blog(LOG_ERROR, "Size of the image in the header are null");
+			context->processing = false;
 			return false;
 		}
 

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -120,7 +120,7 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 		auto *region = new mapped_region(shm, read_only);
 		context->region = region;
 
-		auto *python_header = static_cast<shared_frame_header_t *>(region.get_address());
+		auto *python_header = static_cast<shared_frame_header_t *>(region->get_address());
 
 				// Validate header
 		if (python_header->width == 0 || python_header->height == 0) {

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -11,6 +11,7 @@
 #include "shared_memory_wrapper.h"
 
 #include <boost/interprocess/shared_memory_object.hpp>
+#include <boost/interprocess/windows_shared_memory.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 
 struct shared_frame_header {
@@ -43,7 +44,7 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 		context->region = nullptr;
 	}
 
-	shared_memory_object shm(open_or_create, OBS_SHM_NAME, read_write);
+	windows_shared_memory shm(open_or_create, OBS_SHM_NAME, read_write);
 	shm.truncate(static_cast<offset_t>(required_size));
 
 	context->region = static_cast<void *>(new mapped_region(shm, read_write));

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -109,6 +109,8 @@ extern "C" void destroy_shared_memory(draw_source_data_t *context)
 extern "C" bool read_shared_memory(draw_source_data_t *context)
 {
 	using namespace boost::interprocess;
+
+	blog(LOG_INFO, "reading shared memory")
 	
 	try {
 		windows_shared_memory shm(

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -44,8 +44,7 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 		context->region = nullptr;
 	}
 
-	windows_shared_memory shm(open_or_create, OBS_SHM_NAME, read_write);
-	shm.truncate(static_cast<offset_t>(required_size));
+	windows_shared_memory shm(open_or_create, OBS_SHM_NAME, read_write, required_size);
 
 	context->region = static_cast<void *>(new mapped_region(shm, read_write));
 	context->shared_frame = static_cast<mapped_region *>(context->region)->get_address();

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -159,7 +159,7 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 			 context->display_height);
 	
 	
-		uint8_t *image_data = static_cast<uint8_t *>(region.get_address()) + sizeof(shared_frame_header_t);
+		uint8_t *image_data = static_cast<uint8_t *>(region->get_address()) + sizeof(shared_frame_header_t);
 	
 		gs_texture_set_image(
 			context->display_texture,


### PR DESCRIPTION
This pull request updates the shared memory implementation in `src/shared_memory_wrapper.cpp` to use Windows-specific shared memory APIs, which should improve compatibility and reliability on Windows systems.

**Platform-specific shared memory changes:**

* Switched from using `shared_memory_object` to `windows_shared_memory` for creating and managing shared memory regions, ensuring the code uses Windows-native APIs for shared memory operations. [[1]](diffhunk://#diff-c1efc8cb5f6d1091908a53b8bf6fe2f3f9e8b030a06387d409f813a48fd5ca60R14) [[2]](diffhunk://#diff-c1efc8cb5f6d1091908a53b8bf6fe2f3f9e8b030a06387d409f813a48fd5ca60L46-R47)
* Added the necessary include for `boost/interprocess/windows_shared_memory.hpp` to support the new implementation.