### PR TITLE
Fix shared memory initialization on start with width and height parameters

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -26,14 +26,14 @@ void *draw_source_create(obs_data_t *settings, obs_source_t *source)
 void draw_source_destroy(void *data)
 {
 	draw_source_data_t *context = data;
-	if (!context->source)
-		return;
-
-	obs_source_t *source = obs_weak_source_get_source(context->source);
-	if (source) {
-		obs_source_release(source);
+	if (context->source) {
+		obs_source_t *source = obs_weak_source_get_source(context->source);
+		if (source) {
+			obs_source_release(source);
+		}
+		obs_weak_source_release(context->source);
 	}
-	obs_weak_source_release(context->source);
+
 	if (context->render) {
 		obs_enter_graphics();
 		gs_texrender_destroy(context->render);

--- a/src/draw.c
+++ b/src/draw.c
@@ -10,7 +10,7 @@
 const char *draw_source_get_name(void *type_data)
 {
 	UNUSED_PARAMETER(type_data);
-	return obs_module_text(obs_module_text("draw_display"));
+	return obs_module_text("draw_display");
 }
 
 void *draw_source_create(obs_data_t *settings, obs_source_t *source)
@@ -26,6 +26,8 @@ void *draw_source_create(obs_data_t *settings, obs_source_t *source)
 void draw_source_destroy(void *data)
 {
 	draw_source_data_t *context = data;
+	if (!context->source)
+		return;
 
 	obs_source_t *source = obs_weak_source_get_source(context->source);
 	if (source) {
@@ -47,14 +49,14 @@ uint32_t draw_source_get_height(void *data)
 {
 	draw_source_data_t *context = data;
 	if (!context->display_height)
-		return 391;
+		return 1195;
 	return context->display_height;
 }
 uint32_t draw_source_get_width(void *data)
 {
 	draw_source_data_t *context = data;
 	if (!context->display_width)
-		return 268;
+		return 813;
 	return context->display_width;
 }
 
@@ -79,8 +81,14 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 		return;
 	}
 
-	uint32_t width = context->source_width;
-	uint32_t height = context->source_height;
+	uint32_t width = obs_source_get_width(source);
+	uint32_t height = obs_source_get_height(source);
+
+	if (width == 0 || height == 0) {
+		obs_source_release(source);
+		context->processing = false;
+		return;
+	}
 
 	gs_texrender_t *render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
 	if (!gs_texrender_begin(render, width, height)) {
@@ -90,7 +98,7 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 		return;
 	}
 
-	ensure_shared_memory_exists(context);
+	ensure_shared_memory_exists(context, width, height);
 
 	struct vec4 clear_color;
 	vec4_set(&clear_color, 0.0f, 0.0f, 0.0f, 1.0f); // black
@@ -125,6 +133,7 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 	obs_source_release(source);
 
 	if (!read_shared_memory(context)) {
+		context->processing = false;
 		return;
 	}
 

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -96,7 +96,7 @@ extern "C" void ensure_shared_memory_exists(draw_source_data_t *context, uint32_
 		context->source_width = width;
 		context->source_height = height;
 
-		shared_memory_object::remove(OBS_SHM_NAME);
+		destroy_shared_memory(context);
 		init_shared_memory(context);
 		return;
 	}

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -88,9 +88,19 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 	return true;
 }
 
-extern "C" void ensure_shared_memory_exists(draw_source_data_t *context)
+extern "C" void ensure_shared_memory_exists(draw_source_data_t *context, uint32_t width, uint32_t height)
 {
 	using namespace boost::interprocess;
+
+	if (width != context->source_width || height != context->source_height) {
+		context->source_width = width;
+		context->source_height = height;
+
+		shared_memory_object::remove(OBS_SHM_NAME);
+		init_shared_memory(context);
+		return;
+	}
+
 	try {
 		shared_memory_object shm(open_only, OBS_SHM_NAME, read_only);
 	} catch (const interprocess_exception &ex) {

--- a/src/shared_memory_wrapper.h
+++ b/src/shared_memory_wrapper.h
@@ -16,7 +16,7 @@ void write_message_to_shared_memory(draw_source_data_t *context, uint8_t *frame,
 void init_shared_memory(draw_source_data_t *context);
 void destroy_shared_memory(draw_source_data_t *context);
 bool read_shared_memory(draw_source_data_t *context);
-void ensure_shared_memory_exists(draw_source_data_t *context);
+void ensure_shared_memory_exists(draw_source_data_t *context, uint32_t width, uint32_t height);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This pull request introduces several updates to the `draw` source implementation, focusing on improving robustness and correctness in handling shared memory and source dimensions. The main themes are enhanced error handling, dynamic shared memory management based on source size, and updated default dimensions.

**Shared memory and source dimension management improvements:**

* Updated `ensure_shared_memory_exists` to accept `width` and `height` parameters, recreating shared memory when the source size changes, and updated all relevant calls and declarations to match the new signature. (`src/shared_memory_wrapper.cpp`, `src/shared_memory_wrapper.h`, `src/draw.c`) [[1]](diffhunk://#diff-c1efc8cb5f6d1091908a53b8bf6fe2f3f9e8b030a06387d409f813a48fd5ca60L91-R103) [[2]](diffhunk://#diff-5e8ff1c6d02f252411cde3aadfb8c52900ecab5089e62b2a88546f43400352beL19-R19) [[3]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaL93-R101)
* Changed the way source dimensions are retrieved in `draw_source_video_render` to use `obs_source_get_width` and `obs_source_get_height`, ensuring up-to-date values and adding early exit if dimensions are zero. (`src/draw.c`)
* Updated default values for display width and height to `813` and `1195` respectively, ensuring the source has more appropriate fallback dimensions. (`src/draw.c`)

**Robustness and error handling:**

* Added checks in `draw_source_destroy` and `draw_source_video_render` to prevent processing or releasing resources when the source is missing or dimensions are invalid, improving stability. (`src/draw.c`) [[1]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaR29-R30) [[2]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaR136)

**Minor cleanup:**

* Simplified `draw_source_get_name` by removing redundant nested function calls. (`src/draw.c`)