### PR TITLE
Add support for 4K resolution in shared memory initialization

### DIFF
--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -8,6 +8,10 @@
 #define OBS_SHM_NAME "obs_shared_memory"
 #define PYTHON_SHM_NAME "python_shared_memory"
 
+#define MAX_FRAME_WIDTH 3840
+#define MAX_FRAME_HEIGHT 2160
+#define BYTES_PER_PIXEL 4
+
 #include "shared_memory_wrapper.h"
 
 #include <boost/interprocess/shared_memory_object.hpp>
@@ -48,8 +52,9 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 		return;
 	}
 
-	size_t pixel_bytes = size_t(context->source_width) * size_t(context->source_height) * 4;
+	size_t pixel_bytes = MAX_FRAME_WIDTH * MAX_FRAME_HEIGHT * BYTES_PER_PIXEL;
 	size_t required_size = sizeof(shared_frame_header_t) + pixel_bytes;
+	blog(LOG_INFO, "Initializing shared memory for draw2 with size %zu", required_size);
 
 	if (context->region) {
 		delete static_cast<mapped_region *>(context->region);


### PR DESCRIPTION
This pull request updates the shared memory initialization logic to use fixed maximum frame dimensions and improves logging for debugging. The most important changes are grouped below:

Shared memory allocation improvements:

* The calculation for `pixel_bytes` now uses fixed constants (`MAX_FRAME_WIDTH`, `MAX_FRAME_HEIGHT`, `BYTES_PER_PIXEL`) instead of the context's source dimensions, ensuring consistent memory allocation for all frames. [[1]](diffhunk://#diff-c1efc8cb5f6d1091908a53b8bf6fe2f3f9e8b030a06387d409f813a48fd5ca60R11-R14) [[2]](diffhunk://#diff-c1efc8cb5f6d1091908a53b8bf6fe2f3f9e8b030a06387d409f813a48fd5ca60L51-R57)

Logging enhancements:

* Added a log statement to provide visibility into the allocated shared memory size during initialization, aiding in debugging and monitoring.