### PR TITLE
Fix flags check, texture staging, and code cleanliness

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -228,11 +228,13 @@ obs_properties_t *draw_source_get_properties(void *data)
 
 void switch_source(draw_source_data_t *context, obs_source_t *source)
 {
-	obs_source_t *prev_source = obs_weak_source_get_source(context->source);
-	if (prev_source) {
-		obs_source_release(prev_source);
+	if (context->source) {
+		obs_source_t *prev_source = obs_weak_source_get_source(context->source);
+		if (prev_source) {
+			obs_source_release(prev_source);
+		}
+		obs_weak_source_release(context->source);
 	}
-	obs_weak_source_release(context->source);
 	context->source = obs_source_get_weak_source(source);
 }
 void draw_source_update(void *data, obs_data_t *settings)

--- a/src/draw.c
+++ b/src/draw.c
@@ -2,6 +2,9 @@
 // Created by HichTala on 24/06/25.
 //
 
+#define DEFAULT_DISPLAY_CARD_HEIGHT 1195
+#define DEFAULT_DISPLAY_CARD_WIDTH 813
+
 #include "draw.h"
 #include "shared_memory_wrapper.h"
 
@@ -47,14 +50,14 @@ uint32_t draw_source_get_height(void *data)
 {
 	draw_source_data_t *context = data;
 	if (!context->display_height)
-		return 1195;
+		return DEFAULT_DISPLAY_CARD_HEIGHT;
 	return context->display_height;
 }
 uint32_t draw_source_get_width(void *data)
 {
 	draw_source_data_t *context = data;
 	if (!context->display_width)
-		return 813;
+		return DEFAULT_DISPLAY_CARD_WIDTH;
 	return context->display_width;
 }
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -5,8 +5,6 @@
 #include "draw.h"
 #include "shared_memory_wrapper.h"
 
-#include <errno.h>
-
 const char *draw_source_get_name(void *type_data)
 {
 	UNUSED_PARAMETER(type_data);

--- a/src/draw.c
+++ b/src/draw.c
@@ -111,8 +111,8 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 	gs_texture_t *texture = gs_texrender_get_texture(render);
 	if (texture) {
 		gs_stagesurf_t *stage = gs_stagesurface_create(width, height, GS_RGBA);
-		gs_stage_texture(stage, texture);
 		if (stage) {
+			gs_stage_texture(stage, texture);
 			uint8_t *frame = NULL;
 			uint32_t linesize = 0;
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -187,7 +187,7 @@ bool add_source_to_list(void *data, obs_source_t *source)
 	uint32_t flags = obs_source_get_output_flags(source);
 	const char *source_id = obs_source_get_id(source);
 
-	if (flags & OBS_SOURCE_VIDEO & (strcmp(source_id, "draw_source") != 0)) {
+	if ((flags & OBS_SOURCE_VIDEO) && (strcmp(source_id, "draw_source") != 0)) {
 		obs_property_list_insert_string(prop, idx, name, name);
 	}
 	return true;


### PR DESCRIPTION
This pull request introduces improvements to the `src/draw.c` file, focusing on code maintainability, correctness, and resource management. The most important changes include replacing hardcoded display dimensions with constants, fixing logical errors, and ensuring proper handling of source switching.

**Maintainability and Code Consistency:**
* Replaced hardcoded display card height and width values with `DEFAULT_DISPLAY_CARD_HEIGHT` and `DEFAULT_DISPLAY_CARD_WIDTH` constants, improving readability and maintainability.
* Updated `draw_source_get_height` and `draw_source_get_width` functions to use the new constants instead of magic numbers.

**Bug Fixes:**
* Corrected the logical condition in `add_source_to_list` to properly check both the video flag and source ID, preventing unintended behavior.

**Resource Management:**
* Improved the `switch_source` function to release the previous source only if it exists, preventing potential resource leaks.

**Rendering Logic:**
* Moved the `gs_stage_texture` call inside the stage creation check in `draw_source_video_render`, ensuring that the function is only called when the stage is valid.