### PR TITLE
Refactor shared memory and texture management in rendering

### DIFF
--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -168,7 +168,7 @@ void DrawDock::StopPythonDraw()
 	}
 }
 
-void DrawDock::initialize_python_interpreter() const
+void DrawDock::initialize_python_interpreter()
 {
 	blog(LOG_INFO, "Initializing Python interpreter ");
 

--- a/src/DrawDock.hpp
+++ b/src/DrawDock.hpp
@@ -36,7 +36,7 @@ private slots:
 	void SettingsButtonClicked();
 	void StartPythonDraw();
 	void StopPythonDraw();
-	void initialize_python_interpreter() const;
+	void initialize_python_interpreter();
 };
 
 void initialize_python_interpreter();

--- a/src/draw.c
+++ b/src/draw.c
@@ -42,9 +42,9 @@ void draw_source_destroy(void *data)
 	if (context->stage) {
 		gs_stagesurface_destroy(context->stage);
 	}
-	obs_leave_graphics();
 	if (context->display_texture)
 		gs_texture_destroy(context->display_texture);
+	obs_leave_graphics();
 	if (context->shared_frame)
 		destroy_shared_memory(context);
 
@@ -132,8 +132,8 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 			obs_leave_graphics();
 		}
 
-		gs_stage_texture(context->stage, texture);
 		if (context->stage) {
+			gs_stage_texture(context->stage, texture);
 			uint8_t *frame = NULL;
 			uint32_t linesize = 0;
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -19,6 +19,7 @@ void *draw_source_create(obs_data_t *settings, obs_source_t *source)
 	draw_source_data_t *context = bzalloc(sizeof(draw_source_data_t));
 	context->shared_frame = NULL;
 	context->display_texture = NULL;
+	context->render = NULL;
 	obs_source_update(source, NULL);
 	return context;
 }
@@ -90,11 +91,19 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 		return;
 	}
 
-	gs_texrender_t *render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
-	if (!gs_texrender_begin(render, width, height)) {
+	if (!context->render || width != context->source_width || height != context->source_height) {
+		obs_enter_graphics();
+		if (context->render)
+			gs_texrender_destroy(context->render);
+		context->render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		obs_leave_graphics();
+	}
+
+	gs_texrender_reset(context->render);
+	if (!gs_texrender_begin(context->render, width, height)) {
+		blog(LOG_INFO, "Failed to begin texture rendering");
 		obs_source_release(source);
 		context->processing = false;
-		gs_texrender_destroy(render);
 		return;
 	}
 
@@ -106,9 +115,9 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 	gs_ortho(0.0f, (float)width, 0.0f, (float)height, -100.0f, 100.0f);
 
 	obs_source_video_render(source);
-	gs_texrender_end(render);
+	gs_texrender_end(context->render);
 
-	gs_texture_t *texture = gs_texrender_get_texture(render);
+	gs_texture_t *texture = gs_texrender_get_texture(context->render);
 	if (texture) {
 		gs_stagesurf_t *stage = gs_stagesurface_create(width, height, GS_RGBA);
 		gs_stage_texture(stage, texture);
@@ -129,7 +138,6 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 		}
 	}
 
-	gs_texrender_destroy(render);
 	obs_source_release(source);
 
 	if (!read_shared_memory(context)) {

--- a/src/draw.c
+++ b/src/draw.c
@@ -43,9 +43,11 @@ void draw_source_destroy(void *data)
 		gs_stagesurface_destroy(context->stage);
 	}
 	obs_leave_graphics();
-	if (context->shared_frame) {
+	if (context->display_texture)
+		gs_texture_destroy(context->display_texture);
+	if (context->shared_frame)
 		destroy_shared_memory(context);
-	}
+
 	bfree(context);
 }
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -35,11 +35,14 @@ void draw_source_destroy(void *data)
 		obs_weak_source_release(context->source);
 	}
 
+	obs_enter_graphics();
 	if (context->render) {
-		obs_enter_graphics();
 		gs_texrender_destroy(context->render);
-		obs_leave_graphics();
 	}
+	if (context->stage) {
+		gs_stagesurface_destroy(context->stage);
+	}
+	obs_leave_graphics();
 	if (context->shared_frame) {
 		destroy_shared_memory(context);
 	}
@@ -119,19 +122,25 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 
 	gs_texture_t *texture = gs_texrender_get_texture(context->render);
 	if (texture) {
-		gs_stagesurf_t *stage = gs_stagesurface_create(width, height, GS_RGBA);
-		gs_stage_texture(stage, texture);
-		if (stage) {
+		if (!context->stage || width != context->source_width || height != context->source_height) {
+			obs_enter_graphics();
+			if (context->stage)
+				gs_stagesurface_destroy(context->stage);
+			context->stage = gs_stagesurface_create(width, height, GS_RGBA);
+			obs_leave_graphics();
+		}
+
+		gs_stage_texture(context->stage, texture);
+		if (context->stage) {
 			uint8_t *frame = NULL;
 			uint32_t linesize = 0;
 
-			if (gs_stagesurface_map(stage, &frame, &linesize)) {
+			if (gs_stagesurface_map(context->stage, &frame, &linesize)) {
 				if (context->shared_frame) {
 					write_message_to_shared_memory(context, frame, linesize, width, height);
 				}
-				gs_stagesurface_unmap(stage);
+				gs_stagesurface_unmap(context->stage);
 			}
-			gs_stagesurface_destroy(stage);
 
 		} else {
 			blog(LOG_ERROR, "Failed to capture stage surface");

--- a/src/draw.h
+++ b/src/draw.h
@@ -21,6 +21,7 @@ struct draw_source_data {
 	uint32_t source_height;
 
 	gs_texrender_t *render;
+	gs_stagesurf_t *stage;
 	gs_texture_t *display_texture;
 	uint32_t display_width;
 	uint32_t display_height;

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -122,21 +122,16 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 			return false;
 		}
 
-		context->display_width = python_header->width;
-		context->display_height = python_header->height;
-
-		if (
-			!context->display_texture ||
-			context->display_width != python_header->width ||
-			context->display_height != python_header->height
-		) {
+		if (!context->display_texture || context->display_width != python_header->width ||
+		    context->display_height != python_header->height) {
+			context->display_width = python_header->width;
+			context->display_height = python_header->height;
 			if (context->display_texture) {
 				gs_texture_destroy(context->display_texture);
 			}
-			context->display_texture = gs_texture_create(context->display_width, context->display_height, GS_RGBA,
-							     1, nullptr, GS_DYNAMIC);
+			context->display_texture = gs_texture_create(context->display_width, context->display_height,
+								     GS_RGBA, 1, nullptr, GS_DYNAMIC);
 		}
-
 
 		uint8_t *image_data = static_cast<uint8_t *>(region.get_address()) + sizeof(shared_frame_header_t);
 

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -125,11 +125,18 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 		context->display_width = python_header->width;
 		context->display_height = python_header->height;
 
-		if (context->display_texture)
-			gs_texture_destroy(context->display_texture);
-
-		context->display_texture = gs_texture_create(context->display_width, context->display_height, GS_RGBA,
+		if (
+			!context->display_texture ||
+			context->display_width != python_header->width ||
+			context->display_height != python_header->height
+		) {
+			if (context->display_texture) {
+				gs_texture_destroy(context->display_texture);
+			}
+			context->display_texture = gs_texture_create(context->display_width, context->display_height, GS_RGBA,
 							     1, nullptr, GS_DYNAMIC);
+		}
+
 
 		uint8_t *image_data = static_cast<uint8_t *>(region.get_address()) + sizeof(shared_frame_header_t);
 

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -92,11 +92,10 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 extern "C" void destroy_shared_memory(draw_source_data_t *context)
 {
 	using namespace boost::interprocess;
-#ifdef _WIN32
+	delete static_cast<mapped_region *>(context->region);
+#ifndef _WIN32
 	shared_memory_object::remove(OBS_SHM_NAME);
 	shared_memory_object::remove(PYTHON_SHM_NAME);
-#else
-	delete static_cast<mapped_region *>(context->region);
 #endif
 	context->region = nullptr;
 	context->shared_frame = nullptr;


### PR DESCRIPTION
This pull request introduces several improvements to the resource management and rendering logic in the drawing source module. The changes focus on optimizing the creation, destruction, and reuse of rendering and staging surfaces, as well as ensuring proper cleanup and initialization throughout the drawing lifecycle.

Resource management and cleanup improvements:

* Added `stage` member to `draw_source_data_t` and ensured proper creation and destruction of `render`, `stage`, and `display_texture` resources in `draw_source_create`, `draw_source_destroy`, and `draw_source_video_render`. This reduces resource leaks and improves efficiency by reusing surfaces when possible. [[1]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaR22) [[2]](diffhunk://#diff-27c624ceb5eeb0d3d17fb8f0cda8301d059a2997782ad6359865f51a0fe79878R24) [[3]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaL37-R50) [[4]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaL109-L132)
* Improved texture and stage surface handling in `draw_source_video_render` by checking dimensions and recreating resources only when necessary. This prevents unnecessary allocations and ensures correct rendering when source size changes. [[1]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaL93-L97) [[2]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaL109-L132)

Shared memory handling:

* Updated `destroy_shared_memory` to always delete the mapped region and only remove shared memory objects on non-Windows platforms, preventing issues with resource cleanup across platforms.
* Improved texture recreation logic in `read_shared_memory` to handle size changes and ensure that `display_texture` is recreated only when needed.

Code consistency:

* Removed `const` qualifier from `initialize_python_interpreter` in both `DrawDock.cpp` and `DrawDock.hpp` to allow proper initialization and resource management. [[1]](diffhunk://#diff-1388029dd560bd772492c74a05d83d9717095e22fde06a3d27e24e186f5c74c3L171-R171) [[2]](diffhunk://#diff-1ab49052aeb4bd51c238a0a2057d3e09f15d50270bfc55a28ae1617a3caa6bf6L39-R39)