### PR TITLE
Refactor shared memory and texture management in rendering

### DIFF
--- a/README_fr.md
+++ b/README_fr.md
@@ -73,22 +73,8 @@ correctement :
 3. Une fois l'installation terminée, lancez OBS Studio. Si tout est correctement configuré, vous devriez voir dans le
    menu `Docks`
    une nouvelle option appelée `Draw 2`. Vous pouvez activer le dock et le placer où vous le souhaitez.
-4. À ce stade, l'installation n'est pas encore terminée. Vous devez télécharger les poids du modèle DRAW 2.
-   Fermez OBS Studio et ouvrez le dossier dans lequel le plugin est installé. Par défaut, il devrait se trouver dans :
-   `C:\Program Files\draw2`. Ici, vous pouvez ouvrir le dossier `python`, cliquer avec le bouton droit de la souris
-   n'importe où et sélectionner `Ouvrir dans le terminal`.
-5. Dans le terminal, exécutez la commande suivante pour télécharger les poids du modèle :
-   ```bash
-   ./python.exe -c "import draw;draw.run()"
-   ```
-6. À cette étape, vous devriez voir s’afficher des logs dans la console, notamment des barres de progression indiquant le
-   téléchargement des poids du modèle.
-   Lorsque vous voyez
-   ```bash
-    Running Draw2 without OBS shared memory
-    Waiting for OBS to start...
-   ```
-   le téléchargement est terminé, vous pouvez relancer OBS Studio.
+
+   Le téléchargement est terminé ! Bonne détection à tous!
 
 </details>
 

--- a/README_pt-br.md
+++ b/README_pt-br.md
@@ -70,20 +70,8 @@ Siga a instrução de instalação dependendo do seu sistema operacional para qu
 3. Assim que a instalação estiver concluída, execute o OBS Studio. Se tudo foi configurado corretamente, 
    deve-se ver no menu `Painéis` uma nova opção chamada `Draw 2`. 
    Você pode ativar o painel e colocá-lo onde quiser.
-4. Nessa etapa, a instalação não está completa ainda. Você precisa baixar os "model weights" do DRAW 2.
-   Feche o OBS Studio e abra a pasta onde o plugin está instalado. Por padrão, deve estar em: 
-   `C:\Arquivos de Programas\draw2`. Aqui, abra a pasta `python`, clique com o botão direito em qualquer lugar dentro da pasta e selecione `Abrir no Terminal`.
-5. No terminal, execute o seguinte comando para baixar os "model weights":
-   ```bash
-   ./python.exe -c "import draw;draw.run()"
-   ```
-6. Nessa etapa você deve ver alguns logs incluindo barras de progresso baixando os "model weights".
-   Assim que você vir:
-    ```bash
-    Running Draw2 without OBS shared memory
-    Waiting for OBS to start...
-   ```
-   o download foi concluído e você pode reabrir o OBS Studio.
+
+   O download foi concluído!
 </details>
 
 <details>

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -1,6 +1,7 @@
 start_draw="Start DRAW"
 stop_draw="Stop DRAW"
 starting_draw="Starting DRAW..."
+updating_draw="Updating DRAW..."
 draw_display="DRAW Display"
 python_path="Select Python installation:"
 deck_list="Select Deck Lists to use:"

--- a/data/locale/fr-FR.ini
+++ b/data/locale/fr-FR.ini
@@ -1,6 +1,7 @@
 start_draw="Lancer DRAW"
 stop_draw="Arrêter DRAW"
 starting_draw="Lancement en cours..."
+updating_draw="Mis à jour..."
 draw_display="Affichage DRAW"
 python_path="Selection d'une installation Python:"
 deck_list="Selection de la deck list à utiliser:"

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -168,7 +168,7 @@ void DrawDock::StopPythonDraw()
 	}
 }
 
-void DrawDock::initialize_python_interpreter() const
+void DrawDock::initialize_python_interpreter()
 {
 	blog(LOG_INFO, "Initializing Python interpreter ");
 

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -83,6 +83,7 @@ void DrawDock::StartPythonDraw()
 	this->running_flag.store(true);
 	this->should_run.store(true);
 	this->model_ready.store(false);
+	this->update_flag.store(false);
 
 	this->python_thread = std::thread([this]() {
 		blog(LOG_INFO, "Starting Draw2 python backend");
@@ -93,12 +94,16 @@ void DrawDock::StartPythonDraw()
 		if (pModule) {
 			PyObject *pFunc = PyObject_GetAttrString(pModule, "run");
 			if (pFunc && PyCallable_Check(pFunc)) {
-				PyObject *args = PyTuple_New(6);
+				blog(LOG_INFO, "Calling start_draw function in draw module");
+				PyObject *args = PyTuple_New(7);
 				PyObject *capsule_stop = PyCapsule_New(&this->should_run, "stop_flag", nullptr);
 				PyTuple_SetItem(args, 0, capsule_stop);
 
 				PyObject *capsule_ready = PyCapsule_New(&this->model_ready, "model_ready", nullptr);
 				PyTuple_SetItem(args, 1, capsule_ready);
+
+				PyObject *capsule_update = PyCapsule_New(&this->update_flag, "update_flag", nullptr);
+				PyTuple_SetItem(args, 2, capsule_update);
 
 				QSettings settings = QSettings("HichTala", "Draw2");
 
@@ -106,7 +111,7 @@ void DrawDock::StartPythonDraw()
 				QByteArray deck_list_path2 = settings.value("deck_list2", "").toString().toUtf8();
 				QByteArray deck_list_path3 = settings.value("deck_list3", "").toString().toUtf8();
 				const char *plugin_dir = get_plugin_path();
-				PyTuple_SetItem(args, 2,
+				PyTuple_SetItem(args, 3,
 						PyUnicode_FromString((plugin_dir + std::string("/decklists/") +
 								      std::string(deck_list_path1) + std::string(";") +
 								      plugin_dir + std::string("/decklists/") +
@@ -117,15 +122,24 @@ void DrawDock::StartPythonDraw()
 
 				int minimum_out_of_screen_time_value =
 					settings.value("minimum_out_of_screen_time", 25).value<int>();
-				PyTuple_SetItem(args, 3, PyLong_FromLong(minimum_out_of_screen_time_value));
+				PyTuple_SetItem(args, 4, PyLong_FromLong(minimum_out_of_screen_time_value));
 
 				int minimum_screen_time_value = settings.value("minimum_screen_time", 6).value<int>();
-				PyTuple_SetItem(args, 4, PyLong_FromLong(minimum_screen_time_value));
+				PyTuple_SetItem(args, 5, PyLong_FromLong(minimum_screen_time_value));
 
 				int confidence_value = settings.value("confidence_slider", 5).value<int>();
-				PyTuple_SetItem(args, 5, PyLong_FromLong(confidence_value));
+				PyTuple_SetItem(args, 6, PyLong_FromLong(confidence_value));
 
-				PyObject_CallObject(pFunc, args);
+				blog(LOG_INFO, "Arguments prepared, calling start_draw function");
+				PyObject *result = PyObject_CallObject(pFunc, args);
+				if (!result) {
+				    blog(LOG_ERROR, "start_draw raised an exception");
+				    PyErr_Print();
+				} else {
+				    Py_DECREF(result);
+				}
+				Py_DECREF(args);
+				blog(LOG_INFO, "start_draw function returned");
 				Py_DECREF(args);
 
 			} else {
@@ -140,12 +154,17 @@ void DrawDock::StartPythonDraw()
 		this->running_flag.store(false);
 	});
 	std::thread([this]() {
-		for (int i = 0; i < 10000; ++i) {
+		for (int i = 0; i < 50000; ++i) {
 			if (this->model_ready.load()) {
 				this->start_button->setEnabled(true);
 				this->start_button->setText(obs_module_text("stop_draw"));
 				blog(LOG_INFO, "Draw2 python backend started successfully");
 				break;
+			}
+			if (this->update_flag.load()) {
+				this->start_button->setText(obs_module_text("updating_draw"));
+			} else {
+				this->start_button->setText(obs_module_text("starting_draw"));
 			}
 			std::this_thread::sleep_for(std::chrono::milliseconds(100));
 		}

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -94,7 +94,6 @@ void DrawDock::StartPythonDraw()
 		if (pModule) {
 			PyObject *pFunc = PyObject_GetAttrString(pModule, "run");
 			if (pFunc && PyCallable_Check(pFunc)) {
-				blog(LOG_INFO, "Calling start_draw function in draw module");
 				PyObject *args = PyTuple_New(7);
 				PyObject *capsule_stop = PyCapsule_New(&this->should_run, "stop_flag", nullptr);
 				PyTuple_SetItem(args, 0, capsule_stop);
@@ -130,25 +129,22 @@ void DrawDock::StartPythonDraw()
 				int confidence_value = settings.value("confidence_slider", 5).value<int>();
 				PyTuple_SetItem(args, 6, PyLong_FromLong(confidence_value));
 
-				blog(LOG_INFO, "Arguments prepared, calling start_draw function");
 				PyObject *result = PyObject_CallObject(pFunc, args);
 				if (!result) {
-				    blog(LOG_ERROR, "start_draw raised an exception");
-				    PyErr_Print();
+					blog(LOG_ERROR, "Draw2 python backend raised an exception");
+					PyErr_Print();
 				} else {
-				    Py_DECREF(result);
+					Py_DECREF(result);
 				}
-				Py_DECREF(args);
-				blog(LOG_INFO, "start_draw function returned");
 				Py_DECREF(args);
 
 			} else {
-				blog(LOG_ERROR, "Failed to find or call start_draw function.");
+				blog(LOG_ERROR, "Failed to find or call draw run function.");
 			}
 			Py_XDECREF(pFunc);
 			Py_XDECREF(pModule);
 		} else {
-			blog(LOG_ERROR, "Failed to import draw_module.");
+			blog(LOG_ERROR, "Failed to import draw module.");
 		}
 		PyGILState_Release(gstate);
 		this->running_flag.store(false);

--- a/src/DrawDock.hpp
+++ b/src/DrawDock.hpp
@@ -36,7 +36,7 @@ private slots:
 	void SettingsButtonClicked();
 	void StartPythonDraw();
 	void StopPythonDraw();
-	void initialize_python_interpreter() const;
+	void initialize_python_interpreter();
 };
 
 void initialize_python_interpreter();

--- a/src/DrawDock.hpp
+++ b/src/DrawDock.hpp
@@ -29,6 +29,7 @@ private:
 	std::thread python_thread;
 	std::atomic<bool> should_run = false;
 	std::atomic<bool> model_ready = false;
+	std::atomic<bool> update_flag = false;
 	std::atomic<bool> running_flag = false;
 
 private slots:

--- a/src/draw.c
+++ b/src/draw.c
@@ -228,11 +228,13 @@ obs_properties_t *draw_source_get_properties(void *data)
 
 void switch_source(draw_source_data_t *context, obs_source_t *source)
 {
-	obs_source_t *prev_source = obs_weak_source_get_source(context->source);
-	if (prev_source) {
-		obs_source_release(prev_source);
+	if (context->source) {
+		obs_source_t *prev_source = obs_weak_source_get_source(context->source);
+		if (prev_source) {
+			obs_source_release(prev_source);
+		}
+		obs_weak_source_release(context->source);
 	}
-	obs_weak_source_release(context->source);
 	context->source = obs_source_get_weak_source(source);
 }
 void draw_source_update(void *data, obs_data_t *settings)

--- a/src/draw.c
+++ b/src/draw.c
@@ -2,6 +2,9 @@
 // Created by HichTala on 24/06/25.
 //
 
+#define DEFAULT_DISPLAY_CARD_HEIGHT 1195
+#define DEFAULT_DISPLAY_CARD_WIDTH 813
+
 #include "draw.h"
 #include "shared_memory_wrapper.h"
 
@@ -47,14 +50,14 @@ uint32_t draw_source_get_height(void *data)
 {
 	draw_source_data_t *context = data;
 	if (!context->display_height)
-		return 1195;
+		return DEFAULT_DISPLAY_CARD_HEIGHT;
 	return context->display_height;
 }
 uint32_t draw_source_get_width(void *data)
 {
 	draw_source_data_t *context = data;
 	if (!context->display_width)
-		return 813;
+		return DEFAULT_DISPLAY_CARD_WIDTH;
 	return context->display_width;
 }
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -5,8 +5,6 @@
 #include "draw.h"
 #include "shared_memory_wrapper.h"
 
-#include <errno.h>
-
 const char *draw_source_get_name(void *type_data)
 {
 	UNUSED_PARAMETER(type_data);

--- a/src/draw.c
+++ b/src/draw.c
@@ -111,8 +111,8 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 	gs_texture_t *texture = gs_texrender_get_texture(render);
 	if (texture) {
 		gs_stagesurf_t *stage = gs_stagesurface_create(width, height, GS_RGBA);
-		gs_stage_texture(stage, texture);
 		if (stage) {
+			gs_stage_texture(stage, texture);
 			uint8_t *frame = NULL;
 			uint32_t linesize = 0;
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -42,9 +42,9 @@ void draw_source_destroy(void *data)
 	if (context->stage) {
 		gs_stagesurface_destroy(context->stage);
 	}
-	obs_leave_graphics();
 	if (context->display_texture)
 		gs_texture_destroy(context->display_texture);
+	obs_leave_graphics();
 	if (context->shared_frame)
 		destroy_shared_memory(context);
 
@@ -132,8 +132,8 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 			obs_leave_graphics();
 		}
 
-		gs_stage_texture(context->stage, texture);
 		if (context->stage) {
+			gs_stage_texture(context->stage, texture);
 			uint8_t *frame = NULL;
 			uint32_t linesize = 0;
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -187,7 +187,7 @@ bool add_source_to_list(void *data, obs_source_t *source)
 	uint32_t flags = obs_source_get_output_flags(source);
 	const char *source_id = obs_source_get_id(source);
 
-	if (flags & OBS_SOURCE_VIDEO & (strcmp(source_id, "draw_source") != 0)) {
+	if ((flags & OBS_SOURCE_VIDEO) && (strcmp(source_id, "draw_source") != 0)) {
 		obs_property_list_insert_string(prop, idx, name, name);
 	}
 	return true;

--- a/src/draw.c
+++ b/src/draw.c
@@ -19,6 +19,7 @@ void *draw_source_create(obs_data_t *settings, obs_source_t *source)
 	draw_source_data_t *context = bzalloc(sizeof(draw_source_data_t));
 	context->shared_frame = NULL;
 	context->display_texture = NULL;
+	context->render = NULL;
 	obs_source_update(source, NULL);
 	return context;
 }
@@ -90,11 +91,19 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 		return;
 	}
 
-	gs_texrender_t *render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
-	if (!gs_texrender_begin(render, width, height)) {
+	if (!context->render || width != context->source_width || height != context->source_height) {
+		obs_enter_graphics();
+		if (context->render)
+			gs_texrender_destroy(context->render);
+		context->render = gs_texrender_create(GS_RGBA, GS_ZS_NONE);
+		obs_leave_graphics();
+	}
+
+	gs_texrender_reset(context->render);
+	if (!gs_texrender_begin(context->render, width, height)) {
+		blog(LOG_INFO, "Failed to begin texture rendering");
 		obs_source_release(source);
 		context->processing = false;
-		gs_texrender_destroy(render);
 		return;
 	}
 
@@ -106,9 +115,9 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 	gs_ortho(0.0f, (float)width, 0.0f, (float)height, -100.0f, 100.0f);
 
 	obs_source_video_render(source);
-	gs_texrender_end(render);
+	gs_texrender_end(context->render);
 
-	gs_texture_t *texture = gs_texrender_get_texture(render);
+	gs_texture_t *texture = gs_texrender_get_texture(context->render);
 	if (texture) {
 		gs_stagesurf_t *stage = gs_stagesurface_create(width, height, GS_RGBA);
 		gs_stage_texture(stage, texture);
@@ -129,7 +138,6 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 		}
 	}
 
-	gs_texrender_destroy(render);
 	obs_source_release(source);
 
 	if (!read_shared_memory(context)) {

--- a/src/draw.c
+++ b/src/draw.c
@@ -43,9 +43,11 @@ void draw_source_destroy(void *data)
 		gs_stagesurface_destroy(context->stage);
 	}
 	obs_leave_graphics();
-	if (context->shared_frame) {
+	if (context->display_texture)
+		gs_texture_destroy(context->display_texture);
+	if (context->shared_frame)
 		destroy_shared_memory(context);
-	}
+
 	bfree(context);
 }
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -35,11 +35,14 @@ void draw_source_destroy(void *data)
 		obs_weak_source_release(context->source);
 	}
 
+	obs_enter_graphics();
 	if (context->render) {
-		obs_enter_graphics();
 		gs_texrender_destroy(context->render);
-		obs_leave_graphics();
 	}
+	if (context->stage) {
+		gs_stagesurface_destroy(context->stage);
+	}
+	obs_leave_graphics();
 	if (context->shared_frame) {
 		destroy_shared_memory(context);
 	}
@@ -119,19 +122,25 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 
 	gs_texture_t *texture = gs_texrender_get_texture(context->render);
 	if (texture) {
-		gs_stagesurf_t *stage = gs_stagesurface_create(width, height, GS_RGBA);
-		gs_stage_texture(stage, texture);
-		if (stage) {
+		if (!context->stage || width != context->source_width || height != context->source_height) {
+			obs_enter_graphics();
+			if (context->stage)
+				gs_stagesurface_destroy(context->stage);
+			context->stage = gs_stagesurface_create(width, height, GS_RGBA);
+			obs_leave_graphics();
+		}
+
+		gs_stage_texture(context->stage, texture);
+		if (context->stage) {
 			uint8_t *frame = NULL;
 			uint32_t linesize = 0;
 
-			if (gs_stagesurface_map(stage, &frame, &linesize)) {
+			if (gs_stagesurface_map(context->stage, &frame, &linesize)) {
 				if (context->shared_frame) {
 					write_message_to_shared_memory(context, frame, linesize, width, height);
 				}
-				gs_stagesurface_unmap(stage);
+				gs_stagesurface_unmap(context->stage);
 			}
-			gs_stagesurface_destroy(stage);
 
 		} else {
 			blog(LOG_ERROR, "Failed to capture stage surface");

--- a/src/draw.h
+++ b/src/draw.h
@@ -21,6 +21,7 @@ struct draw_source_data {
 	uint32_t source_height;
 
 	gs_texrender_t *render;
+	gs_stagesurf_t *stage;
 	gs_texture_t *display_texture;
 	uint32_t display_width;
 	uint32_t display_height;

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -122,21 +122,16 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 			return false;
 		}
 
-		context->display_width = python_header->width;
-		context->display_height = python_header->height;
-
-		if (
-			!context->display_texture ||
-			context->display_width != python_header->width ||
-			context->display_height != python_header->height
-		) {
+		if (!context->display_texture || context->display_width != python_header->width ||
+		    context->display_height != python_header->height) {
+			context->display_width = python_header->width;
+			context->display_height = python_header->height;
 			if (context->display_texture) {
 				gs_texture_destroy(context->display_texture);
 			}
-			context->display_texture = gs_texture_create(context->display_width, context->display_height, GS_RGBA,
-							     1, nullptr, GS_DYNAMIC);
+			context->display_texture = gs_texture_create(context->display_width, context->display_height,
+								     GS_RGBA, 1, nullptr, GS_DYNAMIC);
 		}
-
 
 		uint8_t *image_data = static_cast<uint8_t *>(region.get_address()) + sizeof(shared_frame_header_t);
 

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -125,11 +125,18 @@ extern "C" bool read_shared_memory(draw_source_data_t *context)
 		context->display_width = python_header->width;
 		context->display_height = python_header->height;
 
-		if (context->display_texture)
-			gs_texture_destroy(context->display_texture);
-
-		context->display_texture = gs_texture_create(context->display_width, context->display_height, GS_RGBA,
+		if (
+			!context->display_texture ||
+			context->display_width != python_header->width ||
+			context->display_height != python_header->height
+		) {
+			if (context->display_texture) {
+				gs_texture_destroy(context->display_texture);
+			}
+			context->display_texture = gs_texture_create(context->display_width, context->display_height, GS_RGBA,
 							     1, nullptr, GS_DYNAMIC);
+		}
+
 
 		uint8_t *image_data = static_cast<uint8_t *>(region.get_address()) + sizeof(shared_frame_header_t);
 

--- a/src/shared_memory_wrapper.cpp
+++ b/src/shared_memory_wrapper.cpp
@@ -92,11 +92,10 @@ extern "C" void init_shared_memory(draw_source_data_t *context)
 extern "C" void destroy_shared_memory(draw_source_data_t *context)
 {
 	using namespace boost::interprocess;
-#ifdef _WIN32
+	delete static_cast<mapped_region *>(context->region);
+#ifndef _WIN32
 	shared_memory_object::remove(OBS_SHM_NAME);
 	shared_memory_object::remove(PYTHON_SHM_NAME);
-#else
-	delete static_cast<mapped_region *>(context->region);
 #endif
 	context->region = nullptr;
 	context->shared_frame = nullptr;


### PR DESCRIPTION
This pull request introduces several improvements to the resource management and rendering logic in the drawing source module. The changes focus on optimizing the creation, destruction, and reuse of rendering and staging surfaces, as well as ensuring proper cleanup and initialization throughout the drawing lifecycle.

Resource management and cleanup improvements:

* Added `stage` member to `draw_source_data_t` and ensured proper creation and destruction of `render`, `stage`, and `display_texture` resources in `draw_source_create`, `draw_source_destroy`, and `draw_source_video_render`. This reduces resource leaks and improves efficiency by reusing surfaces when possible. [[1]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaR22) [[2]](diffhunk://#diff-27c624ceb5eeb0d3d17fb8f0cda8301d059a2997782ad6359865f51a0fe79878R24) [[3]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaL37-R50) [[4]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaL109-L132)
* Improved texture and stage surface handling in `draw_source_video_render` by checking dimensions and recreating resources only when necessary. This prevents unnecessary allocations and ensures correct rendering when source size changes. [[1]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaL93-L97) [[2]](diffhunk://#diff-ddadcb2df4e2d2b7bd0b6ed3439d2d37a430236144a8fcf9e9706de8c9f936eaL109-L132)

Shared memory handling:

* Updated `destroy_shared_memory` to always delete the mapped region and only remove shared memory objects on non-Windows platforms, preventing issues with resource cleanup across platforms.
* Improved texture recreation logic in `read_shared_memory` to handle size changes and ensure that `display_texture` is recreated only when needed.

Code consistency:

* Removed `const` qualifier from `initialize_python_interpreter` in both `DrawDock.cpp` and `DrawDock.hpp` to allow proper initialization and resource management. [[1]](diffhunk://#diff-1388029dd560bd772492c74a05d83d9717095e22fde06a3d27e24e186f5c74c3L171-R171) [[2]](diffhunk://#diff-1ab49052aeb4bd51c238a0a2057d3e09f15d50270bfc55a28ae1617a3caa6bf6L39-R39)