### PR TITLE
Fix stage surface size mismatch in draw.c

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -125,11 +125,13 @@ void draw_source_video_render(void *data, gs_effect_t *effect)
 
 	gs_texture_t *texture = gs_texrender_get_texture(context->render);
 	if (texture) {
-		if (!context->stage || width != context->source_width || height != context->source_height) {
+		if (!context->stage || width != context->stage_width || height != context->stage_height) {
 			obs_enter_graphics();
 			if (context->stage)
 				gs_stagesurface_destroy(context->stage);
 			context->stage = gs_stagesurface_create(width, height, GS_RGBA);
+			context->stage_width = width;
+			context->stage_height = height;
 			obs_leave_graphics();
 		}
 

--- a/src/draw.h
+++ b/src/draw.h
@@ -22,6 +22,8 @@ struct draw_source_data {
 
 	gs_texrender_t *render;
 	gs_stagesurf_t *stage;
+	uint32_t stage_width;
+	uint32_t stage_height;
 	gs_texture_t *display_texture;
 	uint32_t display_width;
 	uint32_t display_height;


### PR DESCRIPTION
This pull request updates the logic for managing the staging surface in the video rendering pipeline to ensure correct resizing and resource management. The primary improvement is to track the width and height of the staging surface (`stage`) separately, which prevents unnecessary recreation and potential mismatches when the source dimensions change.

**Staging surface management improvements:**

* Added `stage_width` and `stage_height` fields to the `draw_source_data` struct to explicitly track the dimensions of the staging surface.
* Updated the conditional check in `draw_source_video_render` to compare against `stage_width` and `stage_height` instead of `source_width` and `source_height`, ensuring the staging surface is only recreated when its actual size changes.
* Set `stage_width` and `stage_height` after creating a new staging surface to keep the tracked dimensions in sync with the actual resource.