### PR TITLE
fix: update model choice handling to use integer index instead of string

### DIFF
--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -105,8 +105,8 @@ void DrawDock::StartPythonDraw()
 				PyTuple_SetItem(args, 2, capsule_update);
 
 				QSettings settings = QSettings("HichTala", "Draw2");
-				QByteArray model_choice = settings.value("model_choice", "Base").toString().toUtf8();
-				PyTuple_SetItem(args, 3, PyUnicode_FromString(std::string(model_choice).c_str()));
+				int model_choice = settings.value("model_choice", 0).value<int>();
+				PyTuple_SetItem(args, 3, PyLong_FromLong(model_choice));
 
 				QByteArray deck_list_path1 = settings.value("deck_list1", "").toString().toUtf8();
 				QByteArray deck_list_path2 = settings.value("deck_list2", "").toString().toUtf8();

--- a/src/SettingsDialog.cpp
+++ b/src/SettingsDialog.cpp
@@ -59,7 +59,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent)
 	QString deck_list_path1 = settings.value("deck_list1", "").toString();
 	QString deck_list_path2 = settings.value("deck_list2", "").toString();
 	QString deck_list_path3 = settings.value("deck_list3", "").toString();
-	QString model_choice_string = settings.value("model_choice", "Base").toString();
+	int model_choice_int = settings.value("model_choice", 0).toInt();
 	QString python_path_string = settings.value("python_path", "").toString();
 	int minimum_out_of_screen_time_value = settings.value("minimum_out_of_screen_time", 25).value<int>();
 	int minimum_screen_time_value = settings.value("minimum_screen_time", 6).value<int>();
@@ -80,12 +80,9 @@ SettingsDialog::SettingsDialog(QWidget *parent) : QDialog(parent)
 	auto *model_label = new QLabel(obs_module_text("Select model size to use:"), this);
 	model_layout->addWidget(model_label);
 	this->model_choice->setMaximumWidth(125);
-	this->model_choice->addItem(obs_module_text("model_size_large"));
 	this->model_choice->addItem(obs_module_text("model_size_base"));
-	int model_index = this->model_choice->findText(model_choice_string, Qt::MatchExactly);
-	if (model_index != -1) {
-		this->model_choice->setCurrentIndex(model_index);
-	}
+	this->model_choice->addItem(obs_module_text("model_size_large"));
+	this->model_choice->setCurrentIndex(model_choice_int);
 	model_layout->addWidget(this->model_choice);
 	layout->addLayout(model_layout);
 
@@ -191,7 +188,7 @@ void SettingsDialog::OkButtonClicked()
 	settings.setValue("deck_list1", this->deck_list1->currentText());
 	settings.setValue("deck_list2", this->deck_list2->currentText());
 	settings.setValue("deck_list3", this->deck_list3->currentText());
-	settings.setValue("model_choice", this->model_choice->currentText());
+	settings.setValue("model_choice", this->model_choice->currentIndex());
 	settings.setValue("python_path", this->python_path->text());
 	settings.setValue("minimum_screen_time", this->minimum_screen_time->value());
 	settings.setValue("minimum_out_of_screen_time", this->minimum_out_of_screen_time->value());


### PR DESCRIPTION
This pull request updates how the "model_choice" setting is stored and used throughout the application. Instead of saving and retrieving the model choice as a string, it now consistently uses an integer index. This change simplifies the logic for managing the model selection and makes it less error-prone.

**Settings storage and retrieval updates:**

* Changed the storage of `model_choice` in `QSettings` from a string (e.g., "Base") to an integer index, ensuring consistent use of indices for model selection. (`src/SettingsDialog.cpp`, `SettingsDialog::OkButtonClicked`)
* Updated the retrieval of `model_choice` to use an integer index instead of a string, and set the current index of the model selection widget directly. (`src/SettingsDialog.cpp`, `SettingsDialog::SettingsDialog`) [[1]](diffhunk://#diff-61dea4fa3e5367db7b1bf9b500adc50f8937c3f089c35c504d7ea10cd650750eL62-R62) [[2]](diffhunk://#diff-61dea4fa3e5367db7b1bf9b500adc50f8937c3f089c35c504d7ea10cd650750eL83-R85)

**Python integration update:**

* Modified the code that passes the model choice to Python, so it now passes an integer (index) instead of a string. (`src/DrawDock.cpp`, `DrawDock::StartPythonDraw`)