### PR TITLE
fix: crash issue when stopping draw

### DIFF
--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -180,26 +180,8 @@ void DrawDock::StopPythonDraw()
 		return;
 	this->should_run.store(false);
 
-	if (this->python_thread.joinable()) {
-		PyEval_SaveThread();
-		
-		const auto start = std::chrono::steady_clock::now();
-		const auto timeout = std::chrono::seconds(5);
-		std::thread watchdog([this, start, timeout]() {
-			while (this->python_thread.joinable()) {
-				auto elapsed = std::chrono::steady_clock::now() - start;
-				if (elapsed > timeout) {
-					blog(LOG_WARNING, "Python thread join timeout - thread may be blocked by PyTorch");
-					return;
-				}
-				std::this_thread::sleep_for(std::chrono::milliseconds(100));
-			}
-		});
-		watchdog.detach();
-		
-		this->python_thread.join();
-		PyGILState_STATE gstate = PyGILState_Ensure();
-		PyGILState_Release(gstate);
+	if (this->python_thread.joinable()) {		
+		this->python_thread.detach();
 	}
 }
 

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -199,7 +199,7 @@ void DrawDock::StopPythonDraw()
 		
 		this->python_thread.join();
 		PyGILState_STATE gstate = PyGILState_Ensure();
-		PyGILState_Release(gstate)
+		PyGILState_Release(gstate);
 	}
 }
 

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -380,7 +380,7 @@ void DrawDock::initialize_python_interpreter()
 		Py_XDECREF(pModule);
 		blog(LOG_INFO, "Python interpreter initialized successfully");
 #ifdef _WIN32
-		main_thread_state = PyEval_SaveThread();
+		this->main_thread_state = PyEval_SaveThread();
 #endif
 		this->start_button->setEnabled(true);
 	} else {

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -190,7 +190,7 @@ void DrawDock::StopPythonDraw()
 	blog(LOG_INFO, "is python thread joinable");
 	if (this->python_thread.joinable()) {	
 		blog(LOG_INFO, "yes it is");
-		//this->python_thread.join();
+		this->python_thread.join();
 		blog(LOG_INFO, "python thread joined");
 	}
 }

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -132,6 +132,7 @@ void DrawDock::StartPythonDraw()
 				PyTuple_SetItem(args, 7, PyLong_FromLong(confidence_value));
 
 				PyObject *result = PyObject_CallObject(pFunc, args);
+				blog(LOG_INFO, "pyobject called");
 				if (!result) {
 					blog(LOG_ERROR, "Draw2 python backend raised an exception");
 					PyErr_Print();
@@ -148,8 +149,11 @@ void DrawDock::StartPythonDraw()
 		} else {
 			blog(LOG_ERROR, "Failed to import draw module.");
 		}
+		blog(LOG_INFO, "pygilstate release");
 		PyGILState_Release(gstate);
+		blog(LOG_INFO, "pygilstate released");
 		this->running_flag.store(false);
+		blog(LOG_INFO, "end of thread");
 	});
 	std::thread([this]() {
 		for (int i = 0; i < 50000; ++i) {
@@ -180,8 +184,11 @@ void DrawDock::StopPythonDraw()
 		return;
 	this->should_run.store(false);
 
-	if (this->python_thread.joinable()) {		
-		this->python_thread.detach();
+	blog(LOG_INFO, "is python thread joinable");
+	if (this->python_thread.joinable()) {	
+		blog(LOG_INFO, "yes it is");
+		this->python_thread.join();
+		blog(LOG_INFO, "python thread joined");
 	}
 }
 

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -181,7 +181,25 @@ void DrawDock::StopPythonDraw()
 	this->should_run.store(false);
 
 	if (this->python_thread.joinable()) {
+		PyEval_SaveThread();
+		
+		const auto start = std::chrono::steady_clock::now();
+		const auto timeout = std::chrono::seconds(5);
+		std::thread watchdog([this, start, timeout]() {
+			while (this->python_thread.joinable()) {
+				auto elapsed = std::chrono::steady_clock::now() - start;
+				if (elapsed > timeout) {
+					blog(LOG_WARNING, "Python thread join timeout - thread may be blocked by PyTorch");
+					return;
+				}
+				std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			}
+		});
+		watchdog.detach();
+		
 		this->python_thread.join();
+		PyGILState_STATE gstate = PyGILState_Ensure();
+		PyGILState_Release(gstate)
 	}
 }
 

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -187,7 +187,7 @@ void DrawDock::StopPythonDraw()
 	blog(LOG_INFO, "is python thread joinable");
 	if (this->python_thread.joinable()) {	
 		blog(LOG_INFO, "yes it is");
-		this->python_thread.join();
+		//this->python_thread.join();
 		blog(LOG_INFO, "python thread joined");
 	}
 }

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -379,9 +379,9 @@ void DrawDock::initialize_python_interpreter()
 		}
 		Py_XDECREF(pModule);
 		blog(LOG_INFO, "Python interpreter initialized successfully");
-#ifdef _WIN32
-		this->main_thread_state = PyEval_SaveThread();
-#endif
+//#ifdef _WIN32
+//		this->main_thread_state = PyEval_SaveThread();
+//#endif
 		this->start_button->setEnabled(true);
 	} else {
 		blog(LOG_INFO, "Failed to initialize Python interpreter");

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -379,9 +379,9 @@ void DrawDock::initialize_python_interpreter()
 		}
 		Py_XDECREF(pModule);
 		blog(LOG_INFO, "Python interpreter initialized successfully");
-//#ifdef _WIN32
-//		this->main_thread_state = PyEval_SaveThread();
-//#endif
+#ifdef _WIN32
+		PyEval_SaveThread();
+#endif
 		this->start_button->setEnabled(true);
 	} else {
 		blog(LOG_INFO, "Failed to initialize Python interpreter");

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -380,7 +380,7 @@ void DrawDock::initialize_python_interpreter()
 		Py_XDECREF(pModule);
 		blog(LOG_INFO, "Python interpreter initialized successfully");
 #ifdef _WIN32
-		PyEval_SaveThread();
+		main_thread_state = PyEval_SaveThread();
 #endif
 		this->start_button->setEnabled(true);
 	} else {

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -259,9 +259,10 @@ void DrawDock::initialize_python_interpreter()
 		PyConfig_SetString(&config, &config.executable, pythonExe);
 		PyConfig_SetString(&config, &config.home, pythonHome);
 
-		putenv(("PYTHONPATH=" + std::string(pyHome) + "/python312.zip;" + std::string(pyHome) +
-			"/Lib/site-packages;" + std::string(pyHome))
-			       .data());
+		static std::string pythonpath = "PYTHONPATH=" + std::string(pyHome) + "/python312.zip;" +
+		                                std::string(pyHome) + "/Lib/site-packages;" +
+		                                std::string(pyHome);
+		putenv(pythonpath.data());
 
 		const char *pyhome_env = getenv("PYTHONHOME");
 		const char *pypath_env = getenv("PYTHONPATH");

--- a/src/DrawDock.cpp
+++ b/src/DrawDock.cpp
@@ -64,9 +64,12 @@ void DrawDock::StartButtonClicked()
 		this->start_button->setText(obs_module_text("starting_draw"));
 		StartPythonDraw();
 	} else {
+		blog(LOG_INFO, "button clicked");
 		StopPythonDraw();
+		blog(LOG_INFO, "python stopped");
 		this->start_button->setText(obs_module_text("start_draw"));
 		this->settings_button->setEnabled(true);
+		blog(LOG_INFO, "After click");
 	}
 }
 

--- a/src/DrawDock.hpp
+++ b/src/DrawDock.hpp
@@ -23,10 +23,10 @@ public:
 	~DrawDock() override;
 
 private:
+	PyThreadState *main_thread_state = nullptr;
 	QWidget *parent = nullptr;
 	QPushButton *start_button = new QPushButton();
 	QPushButton *settings_button = new QPushButton();
-	PyThreadState* main_thread_state = nullptr;
 	std::thread python_thread;
 	std::atomic<bool> should_run = false;
 	std::atomic<bool> model_ready = false;

--- a/src/DrawDock.hpp
+++ b/src/DrawDock.hpp
@@ -5,8 +5,6 @@
 #ifndef DRAW_DOCK_H
 #define DRAW_DOCK_H
 
-#define PY_SSIZE_T_CLEAN
-
 #include <QDockWidget>
 #include <QWidget>
 #include <QPushButton>
@@ -15,8 +13,10 @@
 #include <QApplication>
 #include <QIcon>
 #include <QStyle>
-#include <Python.h>
 #include <thread>
+
+struct _ts;
+typedef struct _ts PyThreadState;
 
 class DrawDock : public QWidget {
 	Q_OBJECT

--- a/src/DrawDock.hpp
+++ b/src/DrawDock.hpp
@@ -5,6 +5,8 @@
 #ifndef DRAW_DOCK_H
 #define DRAW_DOCK_H
 
+#define PY_SSIZE_T_CLEAN
+
 #include <QDockWidget>
 #include <QWidget>
 #include <QPushButton>

--- a/src/DrawDock.hpp
+++ b/src/DrawDock.hpp
@@ -26,6 +26,7 @@ private:
 	QWidget *parent = nullptr;
 	QPushButton *start_button = new QPushButton();
 	QPushButton *settings_button = new QPushButton();
+	PyThreadState* main_thread_state = nullptr;
 	std::thread python_thread;
 	std::atomic<bool> should_run = false;
 	std::atomic<bool> model_ready = false;

--- a/src/DrawDock.hpp
+++ b/src/DrawDock.hpp
@@ -15,9 +15,6 @@
 #include <QStyle>
 #include <thread>
 
-struct _ts;
-typedef struct _ts PyThreadState;
-
 class DrawDock : public QWidget {
 	Q_OBJECT
 
@@ -26,7 +23,6 @@ public:
 	~DrawDock() override;
 
 private:
-	PyThreadState *main_thread_state = nullptr;
 	QWidget *parent = nullptr;
 	QPushButton *start_button = new QPushButton();
 	QPushButton *settings_button = new QPushButton();

--- a/src/DrawDock.hpp
+++ b/src/DrawDock.hpp
@@ -13,6 +13,7 @@
 #include <QApplication>
 #include <QIcon>
 #include <QStyle>
+#include <Python.h>
 #include <thread>
 
 class DrawDock : public QWidget {


### PR DESCRIPTION
This pull request improves the shutdown process for the embedded Python thread in the `DrawDock` class, specifically to handle cases where the thread may hang due to issues with PyTorch. The main change is the addition of a watchdog timer and proper management of the Python Global Interpreter Lock (GIL) during thread shutdown.

Thread shutdown reliability and Python GIL management:

* Added a watchdog timer in `DrawDock::StopPythonDraw()` to log a warning if the Python thread takes longer than 5 seconds to join, helping diagnose hangs (e.g., those caused by PyTorch) (`src/DrawDock.cpp`).
* Improved Python GIL handling by calling `PyEval_SaveThread()` before joining the thread and ensuring the GIL state is properly restored with `PyGILState_Ensure()` and `PyGILState_Release()` after the thread joins (`src/DrawDock.cpp`).