### PR TITLE
docs(macos): document building from source and Python backend setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Medium](https://img.shields.io/badge/-Medium-12100E?style=flat&logo=medium&labelColor=555)](https://medium.com/@hich.tala.phd/how-i-trained-again-my-model-to-detect-and-recognise-a-wide-range-of-yu-gi-oh-cards-5c567a320b0a)
 [![WandB](https://img.shields.io/badge/visualize_in-W%26B-yellow?logo=weightsandbiases&color=%23FFBE00)](https://wandb.ai/hich_/draw)
 
-[🇫🇷 Français](readmes/README_fr.md) | [🇧🇷 Português](readmes/README_pt-br.md) | [🇯🇵 日本語](readmes/README_jp.md)
+[🇫🇷 Français](readmes/README_fr.md) | [🇧🇷 Português](readmes/README_pt-br.md) | [🇯🇵 日本語](readmes/README_jp.md) | [🇪🇸 Español](readmes/README_es.md)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 <div align="center">
-    <p>
-        <img src="https://raw.githubusercontent.com/HichTala/draw2/refs/heads/main/figures/banner-draw.png" alt="DRAW Banner">
-    </p>
-
-
+  <p>
+    <img src="https://raw.githubusercontent.com/HichTala/draw2/refs/heads/main/figures/banner-draw.png" alt="DRAW Banner">
+  </p>
 <div>
 
 [![DRAW2 Workflow](https://github.com/HichTala/draw2-plugin/actions/workflows/push.yaml/badge.svg)](https://github.com/HichTala/draw2-plugin/actions/workflows/push.yaml)
@@ -15,7 +13,6 @@
 [![WandB](https://img.shields.io/badge/visualize_in-W%26B-yellow?logo=weightsandbiases&color=%23FFBE00)](https://wandb.ai/hich_/draw)
 
 [🇫🇷 Français](readmes/README_fr.md) | [🇧🇷 Português](readmes/README_pt-br.md) | [🇯🇵 日本語](readmes/README_jp.md)
-
 
 </div>
 
@@ -32,9 +29,10 @@ The python backend project is available [here](https://github.com/HichTala/draw2
 This project is licensed under the [GNU Affero General Public License v3.0](LICENCE); all contributions are welcome.
 
 ---
+
 ## <div align="center">📰 News</div>
 
-> 🃏 **Latest card pool:** `BLZD` --- last updated `18-05-2026`  
+> 🃏 **Latest card pool:** `BLZD` --- last updated `18-05-2026`
 > 🔧 **Latest app version:** `0.2.1-beta` --- last updated `01-06-2026`
 
 <table>
@@ -92,7 +90,7 @@ Follow the installation instruction depending on your operating system so everyt
 3. Once the installation is complete, launch OBS Studio. If everything is set up correctly, you should see in the
    `Docks` menu
    a new option called `Draw 2`. You can activate the dock and dock it wherever you want.
-   
+
    The download is complete, you can enjoy detecting !
 
 </details>
@@ -101,6 +99,7 @@ Follow the installation instruction depending on your operating system so everyt
 <summary>🐧 Linux</summary>
 
 Coming soon 👀
+
 </details>
 
 <details>
@@ -110,7 +109,91 @@ I'm not familiar enough with OBS on macOS to provide a reliable installation gui
 The plugin is able to compile successfully on macOS, but I haven't tested it thoroughly.
 If you have experience with OBS plugins on macOS and would like to contribute an installation guide,
 please feel free to submit a pull request.
-</details>
+
+#### Building from source (Apple Silicon / macOS 26+)
+
+There is no pre-built macOS release yet, so you have to build the plugin yourself.
+
+1. Install the build prerequisites with [Homebrew](https://brew.sh):
+
+   ```bash
+   brew install cmake ccache coreutils jq xcbeautify
+   ```
+
+   You also need a recent **Xcode** (with its command line tools) and a **Python 3**
+   install (`brew install python`).
+
+2. Configure and build. On Apple Silicon, build for the host architecture only —
+   the universal preset would also build an `x86_64` slice, which fails to link
+   because Homebrew's Python is `arm64`-only:
+
+   ```bash
+   cmake --preset macos -DCMAKE_OSX_ARCHITECTURES=arm64
+   cmake --build build_macos --config RelWithDebInfo
+   ```
+
+   On an Intel Mac, use `-DCMAKE_OSX_ARCHITECTURES=x86_64` instead.
+
+3. The built plugin bundle is produced at:
+
+   ```
+   build_macos/RelWithDebInfo/draw2-plugin.plugin
+   ```
+
+4. Install it by copying the bundle into your OBS plugins folder, then restart OBS:
+
+   ```bash
+   mkdir -p "$HOME/Library/Application Support/obs-studio/plugins"
+   cp -R build_macos/RelWithDebInfo/draw2-plugin.plugin \
+     "$HOME/Library/Application Support/obs-studio/plugins/"
+   ```
+
+   Once OBS restarts, the plugin appears as `Draw 2` in the `Docks` menu.
+
+#### Setting up the Python backend (macOS)
+
+The plugin embeds a Python interpreter and imports the `draw` backend from a
+Python installation **you** provide in the settings (`Select Python installation`).
+There is no automatic download on macOS yet, so you must set this up manually.
+
+> ⚠️ It must be a **full Python prefix (with the standard library)**, _not_ a
+> `venv`/`virtualenv`. The plugin sets `PYTHONHOME` to the folder you select; a
+> venv has no stdlib there and initialization fails with
+> `ModuleNotFoundError: No module named 'encodings'`.
+>
+> The Python **minor version must match the one the plugin was linked against**
+> (currently 3.13). Check with `otool -L .../draw2-plugin | grep -i python`.
+
+1. Get a self-contained CPython matching that version. A relocatable build from
+   [python-build-standalone](https://github.com/astral-sh/python-build-standalone)
+   works well and won't be broken by `brew upgrade`:
+
+   ```bash
+   # pick the install_only build for your arch (aarch64 for Apple Silicon)
+   curl -fL -o python.tar.gz \
+     https://github.com/astral-sh/python-build-standalone/releases/download/<tag>/cpython-3.13.<x>+<tag>-aarch64-apple-darwin-install_only.tar.gz
+   mkdir -p ~/.draw2-runtime && tar -xzf python.tar.gz -C ~/.draw2-runtime
+   ```
+
+2. Install the `draw` backend into that prefix. Use the **`obs-plugin` branch** —
+   that is the one that exposes the `draw.run(...)` entry point the plugin calls
+   (the default `main` branch is the standalone CLI and has no `run`, so the dock
+   will log `Failed to import draw module` / `Failed to find or call draw run function`):
+
+   ```bash
+   ~/.draw2-runtime/python/bin/python -m pip install "git+https://github.com/HichTala/draw2@obs-plugin"
+   ```
+
+3. In the Draw 2 settings, set **Select Python installation** to the prefix folder
+   (the one that contains `bin/` and `lib/`), e.g. `~/.draw2-runtime/python`.
+   Verify the layout expected by the plugin:
+
+   ```text
+   <prefix>/bin/python
+   <prefix>/lib/python3.13/site-packages/draw
+   ```
+
+   </details>
 
 ### 🚀 Usage
 
@@ -118,13 +201,16 @@ When the plugin is installed and the model weights are downloaded, you can launc
 
 1. Open the `Docks` menu and select `Draw 2` to activate the plugin dock.
 2. In the Draw 2 dock, you can configure the plugin settings by clicking on the gear icon next to `Start DRAW` button:
-    - **Select Deck List**: Choose the deck list file that contains the cards you want to detect. 3 deck lists
-      can be handled at the same time. To add new deck lists, you can click the `Open Folder` button and drag and drop
-      your deck list files (in ydk format) into the opened folder.
-    - **Minimum Out of Screen Time**: The minimum time a card just detected can be displayed again.
-    - **Minimum Screen Time**: The minimum time a card is displayed.
-    - **Confidence Threshold**: Set the minimum confidence level for card detection. Detections below this threshold
-      will be ignored.
+   - **Select Python installation**: Path to the Python prefix that has the `draw` backend installed (the folder
+     containing `bin/` and `lib/`). Must be a full Python install, not a virtualenv. See the macOS setup section
+     for details.
+   - **Select Deck List**: Choose the deck list file that contains the cards you want to detect. 3 deck lists
+     can be handled at the same time. To add new deck lists, you can click the `Open Folder` button and drag and drop
+     your deck list files (in ydk format) into the opened folder.
+   - **Minimum Out of Screen Time**: The minimum time a card just detected can be displayed again.
+   - **Minimum Screen Time**: The minimum time a card is displayed.
+   - **Confidence Threshold**: Set the minimum confidence level for card detection. Detections below this threshold
+     will be ignored.
 3. The plugin provide a new source called `Draw Display`. You can add it to your scene like any other source.
    This source will display the detected cards on the screen. You can choose what source/scene to detect cards from.
 4. Click the `Start DRAW` button to start the detection process. The plugin will start detecting cards in real time
@@ -134,14 +220,16 @@ When the plugin is installed and the model weights are downloaded, you can launc
 5. In the other case you can enjoy the plugin!
 
 Here is a small overview :)
+
 <div align="center">
     <img src="https://raw.githubusercontent.com/HichTala/draw2/refs/heads/main/figures/overview.gif" width="960" height="540" />
 </div>
 
 ---
+
 ## <div align="center">🔍Method Overview</div>
 
-A medium blog post explainng the main process from data collection to final prediction has been written. 
+A medium blog post explainng the main process from data collection to final prediction has been written.
 You can access it at [this](https://medium.com/@hich.tala.phd/how-i-trained-again-my-model-to-detect-and-recognise-a-wide-range-of-yu-gi-oh-cards-5c567a320b0a) adress. If you have any questions, don't hesitate to open an issue.
 
 [![Medium](https://img.shields.io/badge/-Medium-12100E?style=flat&logo=medium&labelColor=555)](https://medium.com/@hich.tala.phd/how-i-trained-again-my-model-to-detect-and-recognise-a-wide-range-of-yu-gi-oh-cards-5c567a320b0a)
@@ -158,11 +246,11 @@ at [hich.tala.phd@gmail.com](mailto:hich.tala.phd@gmail.com).
 ## <div align="center">⭐Star History</div>
 
 <div align="center">
-<a href="https://www.star-history.com/#hichtala/draw2&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=hichtala/draw2&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=hichtala/draw2&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=hichtala/draw2&type=date&legend=top-left" />
- </picture>
-</a>
+  <a href="https://www.star-history.com/#hichtala/draw2&type=date&legend=top-left">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=hichtala/draw2&type=date&theme=dark&legend=top-left" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=hichtala/draw2&type=date&legend=top-left" />
+      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=hichtala/draw2&type=date&legend=top-left" />
+    </picture>
+  </a>
 </div>

--- a/readmes/README_es.md
+++ b/readmes/README_es.md
@@ -1,0 +1,261 @@
+<div align="center">
+  <p>
+    <img src="https://raw.githubusercontent.com/HichTala/draw2/refs/heads/main/figures/banner-draw.png" alt="DRAW Banner">
+  </p>
+<div>
+
+[![DRAW2 Workflow](https://github.com/HichTala/draw2-plugin/actions/workflows/push.yaml/badge.svg)](https://github.com/HichTala/draw2-plugin/actions/workflows/push.yaml)
+[![Licence](https://img.shields.io/pypi/l/ultralytics)](../LICENSE)
+[![Github](https://img.shields.io/badge/-github-181717?logo=github&labelColor=555)](https://github.com/HichTala/draw2)
+[![Twitter](https://img.shields.io/badge/-twitter-000?logo=x&labelColor=555)](https://twitter.com/hichtala)
+[![HuggingFace Downloads](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fhuggingface.co%2Fapi%2Fmodels%2FHichTala%2Fdraw2&query=%24.downloads&logo=huggingface&label=downloads&color=%23FFD21E)](https://huggingface.co/HichTala/draw2)
+[![Medium](https://img.shields.io/badge/-Medium-12100E?style=flat&logo=medium&labelColor=555)](https://medium.com/@hich.tala.phd/how-i-trained-again-my-model-to-detect-and-recognise-a-wide-range-of-yu-gi-oh-cards-5c567a320b0a)
+[![WandB](https://img.shields.io/badge/visualize_in-W%26B-yellow?logo=weightsandbiases&color=%23FFBE00)](https://wandb.ai/hich_/draw)
+
+[🇬🇧 English](../README.md) | [🇫🇷 Français](README_fr.md) | [🇧🇷 Português](README_pt-br.md) | [🇯🇵 日本語](README_jp.md)
+
+</div>
+
+</div>
+
+DRAW 2 (que significa **D**etect and **R**ecognize **A** **W**ide range of cards version 2 — detectar y reconocer una
+amplia gama de cartas, versión 2) es un detector de objetos entrenado para detectar cartas de _Yu-Gi-Oh!_ en todo tipo
+de imágenes, y en particular en imágenes de duelos.
+
+Este proyecto es la parte de plugin del sistema DRAW 2. Permite a los usuarios integrar el detector directamente en sus
+directos o vídeos grabados, y todo ello **sin necesidad de conocimientos técnicos particulares**.
+El plugin puede mostrar las cartas detectadas en tiempo real para mejorar la experiencia de quienes lo ven.
+El proyecto del backend de Python está disponible [aquí](https://github.com/HichTala/draw2).
+
+Este proyecto está licenciado bajo la [GNU Affero General Public License v3.0](LICENCE); ¡todas las contribuciones son
+bienvenidas!
+
+---
+
+## <div align="center">📰 Novedades</div>
+
+> 🃏 **Último pool de cartas:** `BLZD` --- última actualización `18-05-2026`
+> 🔧 **Última versión de la app:** `0.2.1-beta` --- última actualización `01-06-2026`
+
+<table>
+  <tr>
+    <th>Fecha</th>
+    <th>Tipo</th>
+    <th>Descripción</th>
+  </tr>
+  <tr>
+    <td><b>01-06-2026</b></td>
+    <td>🔧 Versión de la app</td>
+    <td>Versión 0.2.1-beta publicada --- <a href="https://github.com/HichTala/draw2-plugin/releases/tag/0.2.1">ver notas de la versión</a></td>
+  </tr>
+  <tr>
+    <td><b>18-05-2026</b></td>
+    <td>🃏 Pool de cartas</td>
+    <td>Pool de cartas actualizado --- ahora admite cartas hasta <i>Blazing Dominion</i></td>
+  </tr>
+  <tr>
+    <td><b>06-04-2026</b></td>
+    <td>🃏 Pool de cartas</td>
+    <td>Pool de cartas actualizado --- ahora admite cartas hasta <i>Maze of Muertos</i></td>
+  </tr>
+  <tr>
+    <td><b>06-04-2026</b></td>
+    <td>🔧 Versión de la app</td>
+    <td>Versión 0.2.0-beta publicada --- <a href="https://github.com/HichTala/draw2-plugin/releases/tag/0.2.0">ver notas de la versión</a></td>
+  </tr>
+  <tr>
+    <td><b>09-03-2025</b></td>
+    <td>🔧 Versión de la app</td>
+    <td>Versión 0.1.5-alpha publicada --- <a href="https://github.com/HichTala/draw2-plugin/releases/tag/0.1.5">ver notas de la versión</a></td>
+  </tr>
+  <tr>
+    <td><b>24-08-2025</b></td>
+    <td>🃏 Pool de cartas</td>
+    <td>Pool de cartas actualizado --- ahora admite cartas hasta <i>Justic Hunter</i></td>
+  </tr>
+</table>
+
+---
+
+## <div align="center">📄 Documentación</div>
+
+### 🛠️ Instalación
+
+Sigue las instrucciones de instalación según tu sistema operativo para que todo funcione correctamente:
+
+<details open>
+<summary>🪟 Windows</summary>
+
+1. Descarga el instalador del plugin desde este
+   enlace: [DRAW2 Plugin Installer](https://github.com/HichTala/draw2-plugin/releases/download/0.2.1/draw2-plugin-installer.exe)
+2. Ejecuta el instalador y sigue las instrucciones en pantalla.
+3. Una vez completada la instalación, abre OBS Studio. Si todo está configurado correctamente, deberías ver en el
+   menú `Docks` una nueva opción llamada `Draw 2`. Puedes activar el dock y colocarlo donde quieras.
+
+   ¡La instalación ha terminado, ya puedes disfrutar detectando!
+
+</details>
+
+<details>
+<summary>🐧 Linux</summary>
+
+Próximamente 👀
+
+</details>
+
+<details>
+<summary>🍏 MacOS</summary>
+
+No conozco OBS en macOS lo suficiente como para ofrecer una guía de instalación fiable.
+El plugin compila correctamente en macOS, pero no lo he probado a fondo.
+Si tienes experiencia con plugins de OBS en macOS y quieres contribuir con una guía de instalación,
+no dudes en enviar un pull request.
+
+#### Compilar desde el código fuente (Apple Silicon / macOS 26+)
+
+Todavía no hay una versión precompilada para macOS, así que tienes que compilar el plugin tú mismo.
+
+1. Instala los requisitos de compilación con [Homebrew](https://brew.sh):
+
+   ```bash
+   brew install cmake ccache coreutils jq xcbeautify
+   ```
+
+   También necesitas un **Xcode** reciente (con sus herramientas de línea de comandos) y una instalación de
+   **Python 3** (`brew install python`).
+
+2. Configura y compila. En Apple Silicon, compila solo para la arquitectura del host —
+   el preset universal también compilaría una porción `x86_64`, que falla al enlazar
+   porque el Python de Homebrew es solo `arm64`:
+
+   ```bash
+   cmake --preset macos -DCMAKE_OSX_ARCHITECTURES=arm64
+   cmake --build build_macos --config RelWithDebInfo
+   ```
+
+   En un Mac con Intel, usa `-DCMAKE_OSX_ARCHITECTURES=x86_64` en su lugar.
+
+3. El bundle del plugin compilado se genera en:
+
+   ```
+   build_macos/RelWithDebInfo/draw2-plugin.plugin
+   ```
+
+4. Instálalo copiando el bundle en tu carpeta de plugins de OBS y luego reinicia OBS:
+
+   ```bash
+   mkdir -p "$HOME/Library/Application Support/obs-studio/plugins"
+   cp -R build_macos/RelWithDebInfo/draw2-plugin.plugin \
+     "$HOME/Library/Application Support/obs-studio/plugins/"
+   ```
+
+   Una vez que OBS se reinicie, el plugin aparece como `Draw 2` en el menú `Docks`.
+
+#### Configurar el backend de Python (macOS)
+
+El plugin incorpora un intérprete de Python e importa el backend `draw` desde una
+instalación de Python que **tú** proporcionas en los ajustes (`Select Python installation`).
+Todavía no hay descarga automática en macOS, así que debes configurarlo manualmente.
+
+> ⚠️ Debe ser un **prefijo de Python completo (con la biblioteca estándar)**, _no_ un
+> `venv`/`virtualenv`. El plugin establece `PYTHONHOME` en la carpeta que selecciones; un
+> venv no tiene allí la stdlib y la inicialización falla con
+> `ModuleNotFoundError: No module named 'encodings'`.
+>
+> La **versión menor de Python debe coincidir con aquella contra la que se enlazó el plugin**
+> (actualmente 3.13). Compruébalo con `otool -L .../draw2-plugin | grep -i python`.
+
+1. Consigue un CPython autocontenido que coincida con esa versión. Una compilación reubicable de
+   [python-build-standalone](https://github.com/astral-sh/python-build-standalone)
+   funciona bien y no se romperá con `brew upgrade`:
+
+   ```bash
+   # pick the install_only build for your arch (aarch64 for Apple Silicon)
+   curl -fL -o python.tar.gz \
+     https://github.com/astral-sh/python-build-standalone/releases/download/<tag>/cpython-3.13.<x>+<tag>-aarch64-apple-darwin-install_only.tar.gz
+   mkdir -p ~/.draw2-runtime && tar -xzf python.tar.gz -C ~/.draw2-runtime
+   ```
+
+2. Instala el backend `draw` en ese prefijo. Usa la **rama `obs-plugin`** —
+   esa es la que expone el punto de entrada `draw.run(...)` que el plugin llama
+   (la rama por defecto `main` es la CLI independiente y no tiene `run`, así que el dock
+   registrará `Failed to import draw module` / `Failed to find or call draw run function`):
+
+   ```bash
+   ~/.draw2-runtime/python/bin/python -m pip install "git+https://github.com/HichTala/draw2@obs-plugin"
+   ```
+
+3. En los ajustes de Draw 2, establece **Select Python installation** en la carpeta del prefijo
+   (la que contiene `bin/` y `lib/`), p. ej. `~/.draw2-runtime/python`.
+   Verifica la estructura que espera el plugin:
+
+   ```text
+   <prefix>/bin/python
+   <prefix>/lib/python3.13/site-packages/draw
+   ```
+
+   </details>
+
+### 🚀 Uso
+
+Cuando el plugin está instalado y los pesos del modelo están descargados, puedes abrir OBS Studio.
+
+1. Abre el menú `Docks` y selecciona `Draw 2` para activar el dock del plugin.
+2. En el dock de Draw 2 puedes configurar los ajustes del plugin haciendo clic en el icono de engranaje junto al
+   botón `Start DRAW`:
+   - **Select Python installation**: ruta al prefijo de Python que tiene instalado el backend `draw` (la carpeta que
+     contiene `bin/` y `lib/`). Debe ser una instalación de Python completa, no un virtualenv. Consulta la sección de
+     configuración de macOS para más detalles.
+   - **Select Deck List**: elige el archivo de deck list que contiene las cartas que quieres detectar. Se pueden
+     gestionar hasta 3 deck lists a la vez. Para añadir nuevas deck lists, puedes hacer clic en el botón
+     `Open Folder` y arrastrar y soltar tus archivos de deck list (en formato ydk) en la carpeta que se abre.
+   - **Minimum Out of Screen Time**: el tiempo mínimo que debe pasar para que una carta recién detectada pueda volver
+     a mostrarse.
+   - **Minimum Screen Time**: el tiempo mínimo que se muestra una carta.
+   - **Confidence Threshold**: define el nivel de confianza mínimo para la detección de cartas. Las detecciones por
+     debajo de este umbral se ignorarán.
+3. El plugin proporciona una nueva fuente llamada `Draw Display`. Puedes añadirla a tu escena como cualquier otra
+   fuente. Esta fuente mostrará las cartas detectadas en pantalla. Puedes elegir de qué fuente/escena detectar las
+   cartas.
+4. Haz clic en el botón `Start DRAW` para iniciar el proceso de detección. El plugin empezará a detectar cartas en
+   tiempo real y a mostrarlas en pantalla mediante la fuente `Draw Display`. El plugin comienza a detectar en el
+   momento en que ves el botón `Stop DRAW`. Si no lo ves, algo salió mal.
+5. En caso contrario, ¡disfruta del plugin!
+
+Aquí tienes una pequeña vista previa :)
+
+<div align="center">
+    <img src="https://raw.githubusercontent.com/HichTala/draw2/refs/heads/main/figures/overview.gif" width="960" height="540" />
+</div>
+
+---
+
+## <div align="center">🔍 Descripción del método</div>
+
+Se ha publicado un artículo en Medium que explica el proceso principal, desde la recopilación de datos hasta la
+predicción final. Puedes leerlo en
+[esta](https://medium.com/@hich.tala.phd/how-i-trained-again-my-model-to-detect-and-recognise-a-wide-range-of-yu-gi-oh-cards-5c567a320b0a)
+dirección. Si tienes cualquier pregunta, no dudes en abrir una issue.
+
+[![Medium](https://img.shields.io/badge/-Medium-12100E?style=flat&logo=medium&labelColor=555)](https://medium.com/@hich.tala.phd/how-i-trained-again-my-model-to-detect-and-recognise-a-wide-range-of-yu-gi-oh-cards-5c567a320b0a)
+
+---
+
+## <div align="center">💬 Contacto</div>
+
+Puedes contactarme en Twitter [@hichtala](https://twitter.com/hichtala) o por correo
+en [hich.tala.phd@gmail.com](mailto:hich.tala.phd@gmail.com).
+
+---
+
+## <div align="center">⭐ Historial de Stars</div>
+
+<div align="center">
+  <a href="https://www.star-history.com/#hichtala/draw2&type=date&legend=top-left">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=hichtala/draw2&type=date&theme=dark&legend=top-left" />
+      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=hichtala/draw2&type=date&legend=top-left" />
+      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=hichtala/draw2&type=date&legend=top-left" />
+    </picture>
+  </a>
+</div>

--- a/readmes/README_fr.md
+++ b/readmes/README_fr.md
@@ -14,7 +14,7 @@
 [![Medium](https://img.shields.io/badge/-Medium-12100E?style=flat&logo=medium&labelColor=555)](https://medium.com/@hich.tala.phd/how-i-trained-again-my-model-to-detect-and-recognise-a-wide-range-of-yu-gi-oh-cards-5c567a320b0a)
 [![WandB](https://img.shields.io/badge/visualize_in-W%26B-yellow?logo=weightsandbiases&color=%23FFBE00)](https://wandb.ai/hich_/draw)
 
-[🇬🇧 English](../README.md) | [🇧🇷 Português](README_pt-br.md) | [🇯🇵 日本語](README_jp.md)
+[🇬🇧 English](../README.md) | [🇧🇷 Português](README_pt-br.md) | [🇯🇵 日本語](README_jp.md) | [🇪🇸 Español](README_es.md)
 
 </div>
 

--- a/readmes/README_fr.md
+++ b/readmes/README_fr.md
@@ -112,6 +112,13 @@ Je ne connais pas suffisamment bien OBS sur macOS pour fournir un guide d'instal
 Le plugin peut être compilé avec succès sur macOS, mais je ne l'ai pas testé de manière approfondie.
 Si vous avez de l'expérience avec les plugins OBS sur macOS et que vous souhaitez contribuer à un guide d'installation,
 n'hésitez pas à soumettre une demande d'extraction.
+
+> ℹ️ Le backend Python (`Select Python installation`) doit être configuré
+> manuellement sur macOS. Indiquez un **préfixe Python complet (avec la
+> bibliothèque standard), pas un `venv`**, dont la version correspond à celle
+> liée au plugin (actuellement 3.13), et installez-y le backend depuis la
+> branche **`obs-plugin`** (`pip install "git+https://github.com/HichTala/draw2@obs-plugin"`).
+> Voir la section macOS du [README en anglais](../README.md) pour les détails.
 </details>
 
 ### 🚀 Utilisation

--- a/readmes/README_jp.md
+++ b/readmes/README_jp.md
@@ -11,7 +11,7 @@
 [![Medium](https://img.shields.io/badge/-Medium-12100E?style=flat&logo=medium&labelColor=555)](https://medium.com/@hich.tala.phd/how-i-trained-again-my-model-to-detect-and-recognise-a-wide-range-of-yu-gi-oh-cards-5c567a320b0a)
 [![WandB](https://img.shields.io/badge/visualize_in-W%26B-yellow?logo=weightsandbiases&color=%23FFBE00)](https://wandb.ai/hich_/draw)
 
-[🇬🇧 English](../README.md) | [🇫🇷 Français](README_fr.md) | [🇧🇷 Português](README_pt-br.md)
+[🇬🇧 English](../README.md) | [🇫🇷 Français](README_fr.md) | [🇧🇷 Português](README_pt-br.md) | [🇪🇸 Español](README_es.md)
 
 </div>
 

--- a/readmes/README_jp.md
+++ b/readmes/README_jp.md
@@ -66,6 +66,8 @@ OSに応じた手順に従ってセットアップしてください。
 <summary>🍏 MacOS</summary>
 
 MacOSでのOBSプラグインに詳しくないため、信頼性のあるインストールガイドを提供できません。MacOSでのコンパイルは成功していますが、十分なテストを行っていません。MacOSでのOBSプラグインに詳しい方がいれば、インストールガイドの作成にぜひ協力ください。Pull Requestをお待ちしています。
+
+> ℹ️ macOSではPythonバックエンド（`Select Python installation`）を手動で設定する必要があります。`venv`ではなく、**標準ライブラリを含む完全なPythonのprefix**を指定し、プラグインがリンクしているバージョン（現在は3.13）に合わせ、**`obs-plugin`ブランチ**からバックエンドをインストールしてください（`pip install "git+https://github.com/HichTala/draw2@obs-plugin"`）。詳細は[英語版README](../README.md)のmacOSセクションを参照してください。
 </details>
 
 ### 🚀 使い方

--- a/readmes/README_pt-br.md
+++ b/readmes/README_pt-br.md
@@ -14,7 +14,7 @@
 [![Medium](https://img.shields.io/badge/-Medium-12100E?style=flat&logo=medium&labelColor=555)](https://medium.com/@hich.tala.phd/how-i-trained-again-my-model-to-detect-and-recognise-a-wide-range-of-yu-gi-oh-cards-5c567a320b0a)
 [![WandB](https://img.shields.io/badge/visualize_in-W%26B-yellow?logo=weightsandbiases&color=%23FFBE00)](https://wandb.ai/hich_/draw)
 
-[🇬🇧 English](../README.md) | [🇫🇷 Français](README_fr.md) | [🇯🇵 日本語](README_jp.md)
+[🇬🇧 English](../README.md) | [🇫🇷 Français](README_fr.md) | [🇯🇵 日本語](README_jp.md) | [🇪🇸 Español](README_es.md)
 
 
 </div>

--- a/readmes/README_pt-br.md
+++ b/readmes/README_pt-br.md
@@ -108,6 +108,13 @@ Não sou tão familiar com o OBS no MacOS para fornecer um guida de instalação
 O plugin é capaz de compilar com sucesso no MacOS mas não testei ele completamente.
 Se você tem experiência com plugins do OBS no MacOS e gostaria de contribuir com um guia de instalação, 
 sinta-se livre para enviar um pull request.
+
+> ℹ️ O backend Python (`Select Python installation`) precisa ser configurado
+> manualmente no macOS. Aponte para um **prefixo Python completo (com a
+> biblioteca padrão), não um `venv`**, com a versão correspondente à que o
+> plugin foi vinculado (atualmente 3.13), e instale o backend a partir do
+> branch **`obs-plugin`** (`pip install "git+https://github.com/HichTala/draw2@obs-plugin"`).
+> Veja a seção macOS do [README em inglês](../README.md) para os detalhes.
 </details>
 
 ### 🚀 Uso


### PR DESCRIPTION
## Summary

Documents how to build the plugin from source on macOS and how to set up the Python backend manually, which previously was undocumented.

## What's included

- **New macOS "build from source" section** in `README.md` covering:
  - Building on Apple Silicon / macOS 26+ as a **host-arch-only** build (no universal binary).
  - Prerequisites needed before configuring the CMake project.
- **Python backend setup guide**: how to provide a full Python **prefix** (not a virtualenv) whose **minor version matches** the one the plugin was linked against, with the `draw` backend installed from the `obs-plugin` branch.
- **Localized notes**: short pointers to the English guide added to the French, Japanese and Brazilian-Portuguese READMEs.

## Notes

Docs-only change — no code is touched.
