### PR TITLE
build(macos): fix macOS 26 / Xcode 16 build (AGL, AUTOMOC predefines)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,20 @@ endif()
 if(ENABLE_QT)
   find_package(Qt6 COMPONENTS Widgets Core)
   target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE Qt6::Core Qt6::Widgets)
+
+  if(APPLE AND TARGET WrapOpenGL::WrapOpenGL)
+    # AGL.framework was removed from the macOS 26 SDK, but Qt's FindWrapOpenGL
+    # still adds it to the OpenGL link interface (pulled in transitively by
+    # Qt6::Gui), which makes linking fail with "framework 'AGL' not found".
+    # Strip AGL from the interface; it is unused by this plugin.
+    get_target_property(_draw2_wrapgl_libs WrapOpenGL::WrapOpenGL INTERFACE_LINK_LIBRARIES)
+    if(_draw2_wrapgl_libs)
+      list(FILTER _draw2_wrapgl_libs EXCLUDE REGEX "[ /]AGL([./]|$)")
+      set_target_properties(WrapOpenGL::WrapOpenGL PROPERTIES INTERFACE_LINK_LIBRARIES "${_draw2_wrapgl_libs}")
+    endif()
+    unset(_draw2_wrapgl_libs)
+  endif()
+
   target_compile_options(
     ${CMAKE_PROJECT_NAME}
     PRIVATE $<$<C_COMPILER_ID:Clang,AppleClang>:-Wno-quoted-include-in-framework-header -Wno-comma>
@@ -53,6 +67,15 @@ if(ENABLE_QT)
     ${CMAKE_PROJECT_NAME}
     PROPERTIES AUTOMOC ON AUTOUIC ON AUTORCC ON
   )
+
+  if(APPLE)
+    # Qt's AUTOMOC generates moc_predefs.h by invoking the compiler with no
+    # explicit deployment target. On Xcode 16+/clang 17+ the build environment
+    # exports several *_DEPLOYMENT_TARGET variables at once, which clang rejects
+    # with "conflicting deployment targets". The predefines are not required
+    # here, so disable their generation to avoid the bare compiler invocation.
+    set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES AUTOMOC_COMPILER_PREDEFINES OFF)
+  endif()
 endif()
 
 target_sources(${CMAKE_PROJECT_NAME} PRIVATE src/plugin-main.cpp)


### PR DESCRIPTION
## Summary

Fixes two macOS build failures that prevent the plugin from compiling on a current toolchain (macOS 26 SDK, Xcode 16+ / clang 17+). Both are **build-system only** and independent of the plugin's runtime behaviour — the plugin still embeds libpython exactly as before.

## Motivation

On a clean checkout, `cmake --preset macos` + build fails twice:

1. **`ld: framework 'AGL' not found`.** `AGL.framework` was removed from the macOS 26 SDK, but Qt's `FindWrapOpenGL` still adds it to the OpenGL link interface (pulled in transitively by `Qt6::Gui`). The plugin does not use AGL, so the reference is spurious — but it breaks linking.
2. **`conflicting deployment targets`.** Qt's AUTOMOC generates `moc_predefs.h` by invoking the compiler with no explicit deployment target. On Xcode 16+ / clang 17+ the build environment exports several `*_DEPLOYMENT_TARGET` variables at once, which clang rejects.

## Changes

`CMakeLists.txt`, inside the existing `if(ENABLE_QT)` block, both guarded by `if(APPLE)` so non-macOS builds are untouched:

- Strip `AGL` from `WrapOpenGL::WrapOpenGL`'s `INTERFACE_LINK_LIBRARIES`.
- Set `AUTOMOC_COMPILER_PREDEFINES OFF` (the predefines are not needed here).

No source files change; no behaviour change.

## Scope / risk

- **macOS-only** (everything is under `if(APPLE)`); Windows/Linux builds are byte-for-byte unaffected. The CI checks on this PR build all three platforms.
- The plugin's Python integration is unchanged (still embedded libpython).
- Lowest-risk possible change: build configuration only.

## How it was tested

Environment: macOS 26 (Apple Silicon), Xcode 16+ / clang 17+, OBS Studio 32.1.1.

**Build from source** — `cmake --preset macos -DCMAKE_OSX_ARCHITECTURES=arm64` then `cmake --build build_macos` → build succeeds and produces `build_macos/<config>/draw2-plugin.plugin`. (On `master` the same build fails at link with `ld: framework 'AGL' not found`.)

![Build succeeds](https://raw.githubusercontent.com/leiteszeke/draw2-plugin/pr-docs/docs/pr/01-macos-build-fix/screenshots/01-build-ok.png)

**Loads in OBS** — the bundle was copied into the OBS plugins folder; OBS launches cleanly and registers the dock: **`Draw 2`** appears (checked) in the `Docks` menu.

![Draw 2 in the Docks menu](https://raw.githubusercontent.com/leiteszeke/draw2-plugin/pr-docs/docs/pr/01-macos-build-fix/screenshots/02-docks-menu.png)

**Dock opens** — activating it shows the `Draw 2` dock (with the `Start DRAW` control) docked alongside the scene.

![Draw 2 dock open](https://raw.githubusercontent.com/leiteszeke/draw2-plugin/pr-docs/docs/pr/01-macos-build-fix/screenshots/03-dock-open.png)

## Notes for reviewers

- Apple Silicon: build `arm64`-only (`-DCMAKE_OSX_ARCHITECTURES=arm64`). Homebrew's `libpython` is `arm64`-only, so a universal build would fail to link the `x86_64` slice — unrelated to this fix, and resolved separately when the backend stops embedding libpython.
